### PR TITLE
USER command 수정 #18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME			= ircserv
 
 CPP				= c++
-CXXFLAGS	= -Wall -Wextra -Werror -std=c++98 -MD
+CXXFLAGS	= -Wall -Wextra -Werror -std=c++98 -MD -g
 RM				= rm -f
 
 GREEN = \033[0;32m

--- a/src/Commands/USER.cpp
+++ b/src/Commands/USER.cpp
@@ -2,13 +2,12 @@
 
 std::string USER(const Message &message, User *sender) {
 	std::string sender_prefix = sender->getServerPrefix();
-	if (message.middle.size() < 4) {
+	if (message.middle.size() + 1 < 4) {
 		return join(sender_prefix, "461", sender->getNickname(), ERR_NEEDMOREPARAMS(message.command));
 	}
 
   std::string username = message.middle[0];
-	std::string realname = message.middle[3];
-
+	std::string realname = message.trailing;
 
 	if (sender->getStatus() == REGISTERED) {
     return join(sender_prefix, "462", sender->getNickname(), ERR_ALREADYREGISTRED());
@@ -16,7 +15,7 @@ std::string USER(const Message &message, User *sender) {
 
 	sender->setUsername(username);
 	sender->setRealname(realname);
-	if (sender->getStatus() == NEED_NICKNAME) {
+	if (sender->getStatus() == NEED_USERREGISTER) {
 		sender->setStatus(REGISTERED);
 	}
 	return std::string();

--- a/src/Commands/USER.cpp
+++ b/src/Commands/USER.cpp
@@ -2,9 +2,10 @@
 
 std::string USER(const Message &message, User *sender) {
 	std::string sender_prefix = sender->getServerPrefix();
-	if (message.middle.size() + 1 < 4) {
+	if (message.middle.size() < 3 || message.trailing.length() == 0) {
 		return join(sender_prefix, "461", sender->getNickname(), ERR_NEEDMOREPARAMS(message.command));
 	}
+
 
   std::string username = message.middle[0];
 	std::string realname = message.trailing;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -151,6 +151,7 @@ void Server::receiveMsg(int user_socket) {
 	buffer[size] = '\0';
 	messages = split(std::string(buffer), MESSAGE_END);
 	for (std::vector<std::string>::iterator msg = messages.begin(); msg != messages.end(); msg++) {
+		std::cout << "|" << *msg << "|" << std::endl;
 		parsed_message = parseMsg(*msg);
 		runCommand(parsed_message, _users[user_socket]);
 	}
@@ -180,18 +181,26 @@ Message Server::parseMsg(std::string message) {
 	parsed_message.command = command;
 	parsed_message.middle = middle;
 	parsed_message.trailing = trailing;
+	std::cout << "command: " << "|" << command << "|" << std::endl;
+	std::cout << "middle: " << std::endl;
+	for (std::vector<std::string>::iterator m = middle.begin(); m != middle.end(); m++) {
+		std::cout << "|" << *m << "|" << std::endl;
+	}
+	std::cout << "trailing: " << "|" << trailing << "|" << std::endl;
 	return parsed_message;
 }
 
 void Server::runCommand(const Message &message, User *user) {
 	std::string	reply;
 
+	std::cout << "Before: " << user->getStatus() << std::endl;
 	if (_executor.find(message.command) != _executor.end()) {
 		sendMsg(_executor[message.command](message, user), user);
 	}
 	else {
 		sendMsg(join(user->getServer()->getServername(), "421", user->getNickname(), ERR_UNKNOWNCOMMAND(message.command)), user);
 	}
+	std::cout << "After: " << user->getStatus() << std::endl;
 	if (user->getStatus() == REGISTERED) {
 		std::cout << user->getNickname() << " registered!" << std::endl;
 	}


### PR DESCRIPTION
1. `realname`에 `trailing` 값을 저장하도록 수정
2. `trailing`을 미입력 시 `ERR_NEEDMOREPARAMS`를 응답하도록 수정
3. user의 상태가 `NEED_USERREGISTER`일 때만 유저 등록이 되도록 수정