### PR TITLE
USER 명령어 수정사항 #18

### DIFF
--- a/src/Commands/USER.cpp
+++ b/src/Commands/USER.cpp
@@ -2,13 +2,12 @@
 
 std::string USER(const Message &message, User *sender) {
 	std::string sender_prefix = sender->getServerPrefix();
-	if (message.middle.size() < 4) {
+	if (message.middle.size() + 1 < 4) {
 		return join(sender_prefix, "461", sender->getNickname(), ERR_NEEDMOREPARAMS(message.command));
 	}
 
   std::string username = message.middle[0];
-	std::string realname = message.middle[3];
-
+	std::string realname = message.trailing;
 
 	if (sender->getStatus() == REGISTERED) {
     return join(sender_prefix, "462", sender->getNickname(), ERR_ALREADYREGISTRED());
@@ -16,7 +15,7 @@ std::string USER(const Message &message, User *sender) {
 
 	sender->setUsername(username);
 	sender->setRealname(realname);
-	if (sender->getStatus() == NEED_NICKNAME) {
+	if (sender->getStatus() == NEED_USERREGISTER) {
 		sender->setStatus(REGISTERED);
 	}
 	return std::string();

--- a/src/Commands/USER.cpp
+++ b/src/Commands/USER.cpp
@@ -2,9 +2,10 @@
 
 std::string USER(const Message &message, User *sender) {
 	std::string sender_prefix = sender->getServerPrefix();
-	if (message.middle.size() + 1 < 4) {
+	if (message.middle.size() < 3 || message.trailing.length() == 0) {
 		return join(sender_prefix, "461", sender->getNickname(), ERR_NEEDMOREPARAMS(message.command));
 	}
+
 
   std::string username = message.middle[0];
 	std::string realname = message.trailing;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -187,13 +187,17 @@ void Server::runCommand(const Message &message, User *user) {
 	std::string	reply;
 
 	if (_executor.find(message.command) != _executor.end()) {
-		sendMsg(_executor[message.command](message, user), user);
+		if (user->getStatus() == NEED_PASSWORD && message.command != "PASS"
+			|| user->getStatus() == NEED_NICKNAME && message.command != "NICK"
+			|| user->getStatus() == NEED_USERREGISTER && message.command != "USER") {
+				sendMsg(join(user->getServer()->getServername(), "451", user->getNickname(), ERR_NOTREGISTERED()), user);
+		}
+		else {
+			sendMsg(_executor[message.command](message, user), user);
+		}
 	}
 	else {
 		sendMsg(join(user->getServer()->getServername(), "421", user->getNickname(), ERR_UNKNOWNCOMMAND(message.command)), user);
-	}
-	if (user->getStatus() == REGISTERED) {
-		std::cout << user->getNickname() << " registered!" << std::endl;
 	}
 }
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -187,9 +187,10 @@ void Server::runCommand(const Message &message, User *user) {
 	std::string	reply;
 
 	if (_executor.find(message.command) != _executor.end()) {
-		if (user->getStatus() == NEED_PASSWORD && message.command != "PASS"
-			|| user->getStatus() == NEED_NICKNAME && message.command != "NICK"
-			|| user->getStatus() == NEED_USERREGISTER && message.command != "USER") {
+		if ((user->getStatus() == NEED_PASSWORD && message.command != "PASS")
+			|| (user->getStatus() == NEED_NICKNAME && message.command != "PASS" && message.command != "NICK")
+			|| (user->getStatus() == NEED_USERREGISTER && message.command != "PASS" && message.command != "NICK" && message.command != "USER"))
+			{
 				sendMsg(join(user->getServer()->getServername(), "451", user->getNickname(), ERR_NOTREGISTERED()), user);
 		}
 		else {


### PR DESCRIPTION
`realname`에 `trailing` 값을 저장하도록 수정
`trailing`을 미입력 시 `ERR_NEEDMOREPARAMS`를 응답하도록 수정
`user`의 상태가 `NEED_USERREGISTER`일 때만 유저 등록이 되도록 수정

> debug용 코드가 레포 커밋에 올라가서 브랜치 삭제 후 다시 올렸습니다