### PR TITLE
PRIVMSG, NOTICE 수정

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ FUNC			=	main \
 					Commands/ADMIN \
 					Commands/INFO \
 					Commands/KILL \
+					Commands/PRIVMSG \
+					Commands/NOTICE \
 
 INC = ./include
 

--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -85,6 +85,8 @@ std::string TIME(const Message &message, User *sender);
 std::string ADMIN(const Message &message, User *sender);
 std::string INFO(const Message &message, User *sender);
 std::string KILL(const Message &message, User *sender);
+std::string PRIVMSG(const Message &message, User *sender);
+std::string NOTICE(const Message &message, User *sender);
 
 // Numeric Replies
 std::string RPL_TRACELINK(const std::string &version, const std::string &debuglevel, const std::string &server, const std::string &nextserver, const std::string &info);
@@ -168,7 +170,7 @@ std::string ERR_WASNOSUCHNICK(const std::string &nickname);
 std::string ERR_TOOMANYTARGETS(const std::string &target);
 std::string ERR_NOSUCHSERVICE(const std::string &service);
 std::string ERR_NOORIGIN(void);
-std::string ERR_NORECIPIENT(void);
+std::string ERR_NORECIPIENT(std::string command);
 std::string ERR_NOTEXTTOSEND(void);
 std::string ERR_NOTOPLEVEL(const std::string &mask);
 std::string ERR_WILDTOPLEVEL(const std::string &mask);

--- a/src/Commands/NOTICE.cpp
+++ b/src/Commands/NOTICE.cpp
@@ -1,0 +1,47 @@
+#include "../../include/Utils.hpp"
+
+std::string NOTICE(const Message &message, User *sender) {
+	std::string											sender_prefix = sender->getUserPrefix();
+	std::string											target = sender->getNickname();
+	std::vector<std::string>							recipient;
+	Channel												*channel;
+	std::vector<std::pair<std::string, std::string> >	responses;
+
+	if (message.middle.empty()) {
+		return std::string();
+	}
+	if (!message.trailing.length()) {
+		return std::string();
+	}
+
+	recipient = split(message.middle[0], ",");
+	for (std::vector<std::string>::iterator it = recipient.begin();it != recipient.end();it++) {
+		if ((*it)[0] == '#') {//channel
+			channel = sender->getServer()->getChannelByName(*it);
+			if (channel) {
+				if (channel->getMode() & FLAG_CHANNEL_N) {
+					if (!channel->checkOnChannel(sender)) {
+						continue;
+					}
+				}
+				std::vector<std::string> user_list = split(channel->getUserList(sender), " ");
+				for (std::vector<std::string>::iterator it2 = user_list.begin();it2 != user_list.end();it2++) {
+					if ((*it2)[0] == '@') {
+						(*it2).erase((*it2).begin());
+					}
+					responses.push_back(make_pair("301", *it2));
+				}
+			}
+		} else {//user
+			if (sender->getServer()->getUserByName(*it)) {
+				responses.push_back(make_pair("301", *it));
+			}
+		}
+	}
+
+	for (std::vector<std::pair<std::string, std::string> >::iterator it = responses.begin();it != responses.end();it++) {
+		User *user = sender->getServer()->getUserByName(it->second);
+		sender->getServer()->sendMsg(join(sender_prefix, "301", user->getNickname(), RPL_AWAY(user->getNickname(), message.trailing)), user);
+	}
+	return std::string();
+}

--- a/src/Commands/PRIVMSG.cpp
+++ b/src/Commands/PRIVMSG.cpp
@@ -1,0 +1,61 @@
+#include "../../include/Utils.hpp"
+
+std::string PRIVMSG(const Message &message, User *sender) {
+	std::string											server_prefix = sender->getServerPrefix();
+	std::string											sender_prefix = sender->getUserPrefix();
+	std::string											target = sender->getNickname();
+	std::vector<std::string>							recipient;
+	Channel												*channel;
+	std::vector<std::pair<std::string, std::string> >	responses;
+
+	// ERR_NORECIPIENT
+	if (message.middle.empty()) {
+		return join(server_prefix, "411", target, ERR_NORECIPIENT(message.command));
+	}
+	// ERR_NOTEXTTOSEND
+	if (!message.trailing.length()) {
+		return join(server_prefix, "412", target, ERR_NOTEXTTOSEND());
+	}
+
+	recipient = split(message.middle[0], ",");
+	for (std::vector<std::string>::iterator it = recipient.begin();it != recipient.end();it++) {
+		if ((*it)[0] == '#') {//channel
+			channel = sender->getServer()->getChannelByName(*it);
+			if (!channel) {
+				responses.push_back(make_pair("401", *it));
+			} else {
+				if (channel->getMode() & FLAG_CHANNEL_N) {
+					if (!channel->checkOnChannel(sender)) {
+						responses.push_back(make_pair("404", *it));
+						continue;
+					}
+				}
+				std::vector<std::string> user_list = split(channel->getUserList(sender), " ");
+				for (std::vector<std::string>::iterator it2 = user_list.begin();it2 != user_list.end();it2++) {
+					if ((*it2)[0] == '@') {
+						(*it2).erase((*it2).begin());
+					}
+					responses.push_back(make_pair("301", *it2));
+				}
+			}
+		} else {//user
+			if (!sender->getServer()->getUserByName(*it)) {
+				responses.push_back(make_pair("401", *it));
+			} else {
+				responses.push_back(make_pair("301", *it));
+			}
+		}
+	}
+
+	for (std::vector<std::pair<std::string, std::string> >::iterator it = responses.begin();it != responses.end();it++) {
+		if (it->first == "401") {
+			sender->getServer()->sendMsg(join(server_prefix, "401", target, ERR_NOSUCHNICK(it->second)), sender);
+		} else if (it->first == "404") {
+			sender->getServer()->sendMsg(join(server_prefix, "404", target, ERR_CANNOTSENDTOCHAN(it->second)), sender);
+		} else {
+			User *user = sender->getServer()->getUserByName(it->second);
+			sender->getServer()->sendMsg(join(sender_prefix, "301", user->getNickname(), RPL_AWAY(user->getNickname(), message.trailing)), user);
+		}
+	}
+	return std::string();
+}

--- a/src/NumericReplies.cpp
+++ b/src/NumericReplies.cpp
@@ -100,9 +100,24 @@ std::string ERR_NOSUCHCHANNEL(const std::string &channel) {
 	return channel + " :No such channel";
 }
 
+// 404
+std::string ERR_CANNOTSENDTOCHAN(const std::string &channel) {
+	return channel + " :Cannot send to channel";
+}
+
 // 405
 std::string ERR_TOOMANYCHANNELS(const std::string &channel) {
 	return channel + " :You have joined too many channels";
+}
+
+// 411
+std::string ERR_NORECIPIENT(std::string command) {
+	return ":No recipient given (" + command + ")";
+}
+
+// 412
+std::string ERR_NOTEXTTOSEND(void) {
+	return ":No text to send";
 }
 
 // 421

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -20,6 +20,8 @@ Server::Server(std::string port, std::string password) {
 	_executor[std::string("ADMIN")] = ADMIN;
 	_executor[std::string("INFO")] = INFO;
 	_executor[std::string("KILL")] = KILL;
+	_executor[std::string("PRIVMSG")] = PRIVMSG;
+	_executor[std::string("NOTICE")] = NOTICE;
 	_servername = SERVER_NAME;
 	_server_version = SERVER_VERSION;
 	_start_time = currTime();
@@ -52,7 +54,7 @@ User *Server::getUserByName(std::string nickname) {
 			return (*it).second;
 		}
 	}
-	return (*_users.end()).second;
+	return NULL;
 }
 
 Channel *Server::getChannelByName(std::string channel_name) {


### PR DESCRIPTION
! server.cpp의 getUserByName함수에서 닉네임이 존재하지 않으면 null을 반환하도록 수정하였습니다.
이 함수를 사용하는 kick과 invite를 테스트할 때도 잘 되지 않아 null로 바꿔서 테스트하니 잘되어서 이렇게 수정하였습니다.

PRIVMSG
채널이 매개변수로 올 경우 n옵션을 확인 후 채널 안에 있는 유저들에게 메시지를 보내고,
닉네임이 매개변수로 올 경우 존재하는 닉네임의 경우에만 메시지를 보내게 했습니다.

NOTICE
PRIVMSG와 오류에 대한 응답을 제외하고는 같습니다.

**+ 매개변수를 "," 기준으로 분리하였고, RPL_AWAY의 sender_prefix도 수정하였습니다.**