### PR TITLE
[CMD] 구현 - PING, PONG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ FUNC			=	main \
 					Commands/KILL \
 					Commands/PRIVMSG \
 					Commands/NOTICE \
+					Commands/PING \
+					Commands/PONG \
 
 INC = ./include
 

--- a/include/User.hpp
+++ b/include/User.hpp
@@ -19,6 +19,8 @@ class User {
 		std::string				_realname;
 		int						_mode;
 		std::set<std::string>	_joined;
+		std::time_t				_last_cmd_time;
+		std::time_t				_ping_time;
 
 	public:
 		User(int user_socket, std::string hostname, Server *server);
@@ -38,6 +40,10 @@ class User {
 		Server		*getServer(void);
 		int			getUserSocket(void);
 		std::set<std::string>	getJoinedChannels(void);
+		std::time_t	getLastCmdTime(void);
+		void		setLastCmdTime(void);
+		std::time_t	getPingTime(void);
+		void		setPingTime(void);
 
 		std::string	getServerPrefix(void);
 		std::string	getUserPrefix(void);

--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -31,6 +31,8 @@
 # define SERVER_VERSION	"2.8"
 # define ADMIN_HOST		"127.0.0.1"
 # define ADMIN_PASSWORD	"pass"
+# define PING_CHECK		15
+# define TIMEOUT		15
 
 # define FLAG_CHANNEL_O	1
 # define FLAG_CHANNEL_P	2
@@ -43,7 +45,6 @@
 # define FLAG_CHANNEL_K	256
 # define FLAG_USER_I	1
 # define FLAG_USER_O	2
-# define FLAG_USER_P	4
 
 // User Status
 enum UserStatus {
@@ -51,7 +52,7 @@ enum UserStatus {
 	NEED_NICKNAME,
 	NEED_USERREGISTER,
 	REGISTERED,
-	DELETE
+	NEED_PONG
 };
 
 // Message Struct

--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -43,6 +43,7 @@
 # define FLAG_CHANNEL_K	256
 # define FLAG_USER_I	1
 # define FLAG_USER_O	2
+# define FLAG_USER_P	4
 
 // User Status
 enum UserStatus {
@@ -87,6 +88,8 @@ std::string INFO(const Message &message, User *sender);
 std::string KILL(const Message &message, User *sender);
 std::string PRIVMSG(const Message &message, User *sender);
 std::string NOTICE(const Message &message, User *sender);
+std::string PING(const Message &message, User *sender);
+std::string PONG(const Message &message, User *sender);
 
 // Numeric Replies
 std::string RPL_TRACELINK(const std::string &version, const std::string &debuglevel, const std::string &server, const std::string &nextserver, const std::string &info);

--- a/src/Commands/PING.cpp
+++ b/src/Commands/PING.cpp
@@ -4,7 +4,7 @@ std::string PING(const Message &message, User *sender) {
 	(void) message;
 	std::string	sender_prefix = sender->getServerPrefix();
 
-	sender->setMode(sender->getMode() | FLAG_USER_P);
+	sender->setStatus(NEED_PONG);
 	sender->setPingTime();
 	sender->getServer()->sendMsg(join(sender_prefix, "PING", sender->getNickname(), ""), sender);
 	

--- a/src/Commands/PING.cpp
+++ b/src/Commands/PING.cpp
@@ -1,0 +1,12 @@
+#include "../../include/Utils.hpp"
+
+std::string PING(const Message &message, User *sender) {
+	(void) message;
+	std::string	sender_prefix = sender->getServerPrefix();
+
+	sender->setMode(sender->getMode() | FLAG_USER_P);
+	sender->setPingTime();
+	sender->getServer()->sendMsg(join(sender_prefix, "PING", sender->getNickname(), ""), sender);
+	
+	return std::string();
+}

--- a/src/Commands/PONG.cpp
+++ b/src/Commands/PONG.cpp
@@ -11,7 +11,7 @@ std::string PONG(const Message &message, User *sender) {
 		return join(sender_prefix, "401", target, ERR_NOSUCHNICK(sender->getNickname()));
 	}
 
-	sender->setMode(sender->getMode() & ~FLAG_USER_P);
+	sender->setStatus(REGISTERED);
 	
 	return std::string();
 }

--- a/src/Commands/PONG.cpp
+++ b/src/Commands/PONG.cpp
@@ -1,0 +1,17 @@
+#include "../../include/Utils.hpp"
+
+std::string PONG(const Message &message, User *sender) {
+	std::string sender_prefix = sender->getServerPrefix();
+	std::string	target = sender->getNickname();
+
+	if (message.middle.size() < 1) {
+		return join(sender_prefix, "409", target, ERR_NOORIGIN());
+	}
+	if (message.middle[0] != sender->getNickname()) {
+		return join(sender_prefix, "401", target, ERR_NOSUCHNICK(sender->getNickname()));
+	}
+
+	sender->setMode(sender->getMode() & ~FLAG_USER_P);
+	
+	return std::string();
+}

--- a/src/NumericReplies.cpp
+++ b/src/NumericReplies.cpp
@@ -110,6 +110,11 @@ std::string ERR_TOOMANYCHANNELS(const std::string &channel) {
 	return channel + " :You have joined too many channels";
 }
 
+// 409
+std::string ERR_NOORIGIN(void) {
+	return ":No origin specified";
+}
+
 // 411
 std::string ERR_NORECIPIENT(std::string command) {
 	return ":No recipient given (" + command + ")";

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -22,6 +22,8 @@ Server::Server(std::string port, std::string password) {
 	_executor[std::string("KILL")] = KILL;
 	_executor[std::string("PRIVMSG")] = PRIVMSG;
 	_executor[std::string("NOTICE")] = NOTICE;
+	_executor[std::string("PING")] = PING;
+	_executor[std::string("PONG")] = PONG;
 	_servername = SERVER_NAME;
 	_server_version = SERVER_VERSION;
 	_start_time = currTime();
@@ -117,7 +119,7 @@ void Server::run(bool &stop) {
 }
 
 void Server::loop(void) {
-	if (poll(&_sockets[0], _sockets.size(), 3000) == -1)
+	if (poll(&_sockets[0], _sockets.size(), 1000) == -1)
 		return;
 
 	if (_sockets[0].revents == POLLIN) {
@@ -127,6 +129,34 @@ void Server::loop(void) {
 		for (std::vector<pollfd>::iterator socket = _sockets.begin(); socket != _sockets.end(); socket++) {
 			if ((*socket).revents == POLLIN) {
 				receiveMsg((*socket).fd);
+				_users[(*socket).fd]->setLastCmdTime();
+			}
+		}
+	}
+
+	// check user and send ping
+	for (std::map<int, User *>::iterator it = _users.begin();it != _users.end();it++) {
+		User *user = (*it).second;
+		time_t now = time(0);
+		if (user->getStatus() < REGISTERED) {
+			continue;
+		}
+		if (now - user->getLastCmdTime() > 15 && !(user->getMode() & FLAG_USER_P)) {
+			_executor["PING"](Message(), user);
+		}
+	}
+
+	// check user received ping
+	for (std::map<int, User *>::iterator it = _users.begin();it != _users.end();it++) {
+		User *user = (*it).second;
+		if (user->getStatus() < REGISTERED) {
+			continue;
+		}
+		if (user->getMode() & FLAG_USER_P) {
+			time_t now = time(0);
+			if (now - user->getPingTime() > 15) {
+				user->setStatus(DELETE);
+				_quitters.push_back(user->getUserSocket());
 			}
 		}
 	}
@@ -167,6 +197,7 @@ void Server::receiveMsg(int user_socket) {
 	for (std::vector<std::string>::iterator msg = messages.begin(); msg != messages.end(); msg++) {
 		parsed_message = parseMsg(*msg);
 		runCommand(parsed_message, _users[user_socket]);
+		
 	}
 }
 

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -7,6 +7,8 @@ User::User(int user_socket, std::string hostname, Server *server) {
 	_server = server;
 	_hostname = hostname;
 	_realname = "";
+	_last_cmd_time = time(0);
+	_ping_time = time(0);
 }
 
 User::~User() {
@@ -83,6 +85,22 @@ int User::getUserSocket(void) {
 
 std::set<std::string> User::getJoinedChannels(void) {
 	return _joined;
+}
+
+std::time_t	User::getLastCmdTime(void) {
+	return _last_cmd_time;
+}
+
+void User::setLastCmdTime(void) {
+	_last_cmd_time = time(0);
+}
+
+std::time_t	User::getPingTime(void) {
+	return _ping_time;
+}
+
+void User::setPingTime(void) {
+	_ping_time = time(0);
 }
 
 void User::joinChannel(std::string channel_name){


### PR DESCRIPTION
추가: user 클래스에 마지막으로 커맨드를 보낸 시간과 ping을 받은 시간을 추가하였고, utils.hpp에 ping, pong을 위한 ~~FLAG_USER_P 플래그~~ NEED_PING 상태를 추가하였습니다.

### PING
REGISTERED 상태인 유저를 대상으로 ping을 확인하고, 마지막 커맨드를 보내고 일정 시간 동안 활동을 하지 않을 경우 유저의 상태를 NEED_PING로 바꾸고 서버에서 유저로 PING 명령어를 보내도록 구현하였습니다. (임의로 15초로 시간을 정했습니다.)

### PONG
ping을 받은 유저가 일정 시간 안에 pong 메시지를 보내도록 하였고, 만약 ping을 받고 일정 시간 내에 pong을 보내지 않으면 유저와의 연결을 닫도록 구현하였습니다. (임의로 15초로 시간을 정했습니다.)

~~만약 ping을 받은 유저가 pong이 아닌 다른 커맨드를 보내 온 경우는 어떻게 처리해야할 지 논의가 필요합니다!~~
~~1. pong을 받을 때까지 ping을 받았다는 상태를 유지할 것인지~~
~~2. 마지막 커맨드 시간을 갱신시키면서 ping 상태가 아니도록 할 지~~
~~3. ping과 pong은 한 묶음이라 생각하고 고려할 필요가 없는지~~

==> flag 사용 대신에 status 사용으로 바꾸었고, ping을 받은 유저의 상태는 유저가 pong을 보내거나 다른 커맨드를 보냈을 경우 활동 상태로 판단하여 상태를 REGISTERED로 바꾸었습니다.