### PR TITLE
register 설정 수정(등록 후 유저가 명령어를 사용하였을 때 마지막 커맨드 사용 시간과 need_ping->register의 경우를 위한 설정)

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -236,8 +236,10 @@ void Server::runCommand(const Message &message, User *user) {
 	else {
 		sendMsg(join(user->getServer()->getServername(), "421", user->getNickname(), ERR_UNKNOWNCOMMAND(message.command)), user);
 	}
-	user->setLastCmdTime();
-	user->setStatus(REGISTERED);
+	if (user->getStatus() >= REGISTERED) {
+		user->setLastCmdTime();
+		user->setStatus(REGISTERED);
+	}
 }
 
 void Server::sendMsg(const std::string &message, User *user) {


### PR DESCRIPTION
등록 후 유저가 명령어를 사용하였을 때 마지막 커맨드 사용 시간과 need_ping->register의 경우를 위한 설정에 대해 수정하였습니다.
> pass
> :tmp.server.name 461 * PASS :Not enough parameters
> time
> :tmp.server.name 391 * tmp.server.name :Tue Dec 13 02:09:20 2022

위와 같은 예시처럼 등록이 되지 않은 상태인데 register 설정이 잘못되어서 수정하였습니다.