### PR TITLE
[CMD] 구현 - WHO, WHOIS, WHOWAS #31

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ FUNC			=	main \
 					Commands/ADMIN \
 					Commands/INFO \
 					Commands/KILL \
+					Commands/WHO \
 					Commands/WHOIS \
 					Commands/WHOWAS \
 					Commands/PRIVMSG \

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ FUNC			=	main \
 					Commands/INFO \
 					Commands/KILL \
 					Commands/WHOIS \
+					Commands/WHOWAS \
 
 INC = ./include
 

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ FUNC			=	main \
 					Commands/ADMIN \
 					Commands/INFO \
 					Commands/KILL \
+					Commands/WHOIS \
 
 INC = ./include
 

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -37,6 +37,7 @@ class Server {
 		std::vector<std::string>			getChannelNames(void);
 		std::string							getStartTime(void);
 		std::string							getServerVersion(void);
+		User										*getUserByFd(int fd);
 
 		void		run(bool &stop);
 		void		loop(void);

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -37,8 +37,6 @@ class Server {
 		std::vector<std::string>			getChannelNames(void);
 		std::string							getStartTime(void);
 		std::string							getServerVersion(void);
-		
-		std::string							currTime(void);
 
 		void		run(bool &stop);
 		void		loop(void);
@@ -52,7 +50,7 @@ class Server {
 		void		deleteChannel(std::string channel_name);
 		void		deleteUser(int user_socket);
 		void		killUser(User *user);
-		
+
 };
 
 #endif

--- a/include/User.hpp
+++ b/include/User.hpp
@@ -19,6 +19,7 @@ class User {
 		std::string				_realname;
 		int						_mode;
 		std::set<std::string>	_joined;
+		time_t	_login_time;
 
 	public:
 		User(int user_socket, std::string hostname, Server *server);
@@ -31,8 +32,10 @@ class User {
 		std::string	getUsername(void);
 		void		setUsername(std::string username);
 		std::string	getHostname(void);
+		void		setHostname(std::string hostname);
 		std::string	getRealname(void);
 		void		setRealname(std::string realname);
+		time_t getLoginTime(void);
 		int			getMode(void);
 		void		setMode(int mode);
 		Server		*getServer(void);

--- a/include/User.hpp
+++ b/include/User.hpp
@@ -19,6 +19,8 @@ class User {
 		std::string				_realname;
 		int						_mode;
 		std::set<std::string>	_joined;
+		std::map<std::string, time_t>	_nick_history;
+		time_t												_nick_update_time;
 		time_t	_login_time;
 
 	public:
@@ -47,6 +49,11 @@ class User {
 
 		void		joinChannel(std::string channel_name);
 		void		leaveChannel(std::string channel_name);
+
+		void		addNickHistory(std::string nickname, time_t nick_update_time);
+		std::map<std::string, time_t>	getNickHistory(void);
+		time_t	getNickUpdateTime(void);
+		void		reNewNickUpdateTime(void);
 
 		void printStatus(void);
 };

--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -66,6 +66,7 @@ std::vector<std::string>	split(std::string str, std::string delimiter);
 std::string					join(std::string sender_prefix, std::string code, std::string target, std::string message);
 std::string					toString(int var);
 std::ostream& operator<<(std::ostream& os, const Message& message);
+std::string currTime(void);
 
 // Commands
 std::string PASS(const Message &message, User *sender);
@@ -85,6 +86,7 @@ std::string TIME(const Message &message, User *sender);
 std::string ADMIN(const Message &message, User *sender);
 std::string INFO(const Message &message, User *sender);
 std::string KILL(const Message &message, User *sender);
+std::string WHOIS(const Message &message, User *sender);
 
 // Numeric Replies
 std::string RPL_TRACELINK(const std::string &version, const std::string &debuglevel, const std::string &server, const std::string &nextserver, const std::string &info);
@@ -127,7 +129,7 @@ std::string RPL_WHOISSERVER(const std::string &nickname, const std::string &serv
 std::string RPL_WHOISOPERATOR(const std::string &nickname);
 std::string RPL_WHOWASUSER(const std::string &nickname, const std::string &username, const std::string &host, const std::string &realname);
 std::string RPL_ENDOFWHO(const std::string &name);
-std::string RPL_WHOISIDLE(const std::string &nickname, const std::string &seconds, const std::string &signon);
+std::string RPL_WHOISIDLE(const std::string &nickname, int seconds);
 std::string RPL_ENDOFWHOIS(const std::string &nickname);
 std::string RPL_WHOISCHANNELS(const std::string &nickname, const std::string &channels);
 std::string RPL_LISTSTART(void);

--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -20,6 +20,7 @@
 # include <poll.h>
 # include <unistd.h>
 # include <ctime>
+# include <regex>
 # include "Server.hpp"
 # include "User.hpp"
 # include "Channel.hpp"
@@ -71,6 +72,8 @@ std::string					toString(int var);
 std::ostream& operator<<(std::ostream& os, const Message& message);
 std::ostream& operator<<(std::ostream& os, const std::map<std::string, time_t>& nick_history);
 std::string currTime(void);
+bool isIncluded(std::string pattern, std::string target);
+bool	confirmMatch(std::string w, std::string s);
 bool						checkMask(std::set<std::string> banlist, std::string host);
 
 // Commands

--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -31,8 +31,8 @@
 # define SERVER_VERSION	"2.8"
 # define ADMIN_HOST		"127.0.0.1"
 # define ADMIN_PASSWORD	"pass"
-# define PING_CHECK		15
-# define TIMEOUT		15
+# define PING_CHECK		150
+# define TIMEOUT		150
 
 # define FLAG_CHANNEL_O	1
 # define FLAG_CHANNEL_P	2
@@ -89,6 +89,7 @@ std::string TIME(const Message &message, User *sender);
 std::string ADMIN(const Message &message, User *sender);
 std::string INFO(const Message &message, User *sender);
 std::string KILL(const Message &message, User *sender);
+std::string WHO(const Message &message, User *sender);
 std::string WHOIS(const Message &message, User *sender);
 std::string WHOWAS(const Message &message, User *sender);
 std::string PRIVMSG(const Message &message, User *sender);
@@ -149,7 +150,7 @@ std::string RPL_TOPIC(const std::string &channel, const std::string &topic);
 std::string RPL_INVITING(const std::string &channel, const std::string &nickname);
 std::string RPL_SUMMONING(const std::string &user);
 std::string RPL_VERSION(const std::string &version, const std::string &debuglevel, const std::string &server, const std::string &comments);
-std::string RPL_WHOREPLY(const std::string &channel, const std::string &user, const std::string &host, const std::string &server, const std::string &nickname, const std::string &hops, const std::string &realname);
+std::string RPL_WHOREPLY(const std::string &channel, const std::string &user, const std::string &host, const std::string &server, const std::string &nickname, const std::string &realname);
 std::string RPL_NAMREPLY(const std::string &channel, const std::string &userlist);
 std::string RPL_LINKS(const std::string &mask, const std::string &server, const std::string &hopcount, const std::string &serverinfo);
 std::string RPL_ENDOFLINKS(const std::string &mask);

--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -73,7 +73,7 @@ std::ostream& operator<<(std::ostream& os, const Message& message);
 std::ostream& operator<<(std::ostream& os, const std::map<std::string, time_t>& nick_history);
 std::string currTime(void);
 bool isIncluded(std::string pattern, std::string target);
-bool	confirmMatch(std::string w, std::string s);
+bool confirmMatch(std::string pattern, std::string target);
 bool						checkMask(std::set<std::string> banlist, std::string host);
 
 // Commands

--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -66,6 +66,7 @@ std::vector<std::string>	split(std::string str, std::string delimiter);
 std::string					join(std::string sender_prefix, std::string code, std::string target, std::string message);
 std::string					toString(int var);
 std::ostream& operator<<(std::ostream& os, const Message& message);
+std::ostream& operator<<(std::ostream& os, const std::map<std::string, time_t>& nick_history);
 std::string currTime(void);
 
 // Commands
@@ -87,6 +88,7 @@ std::string ADMIN(const Message &message, User *sender);
 std::string INFO(const Message &message, User *sender);
 std::string KILL(const Message &message, User *sender);
 std::string WHOIS(const Message &message, User *sender);
+std::string WHOWAS(const Message &message, User *sender);
 
 // Numeric Replies
 std::string RPL_TRACELINK(const std::string &version, const std::string &debuglevel, const std::string &server, const std::string &nextserver, const std::string &info);

--- a/src/Commands/NICK.cpp
+++ b/src/Commands/NICK.cpp
@@ -3,17 +3,20 @@
 std::string NICK(const Message &message, User *sender) {
 	std::string sender_prefix = sender->getServerPrefix();
 
+	// nickname이 입력되지 않은 경우, 431 ERR_NONICKNAMEGIVEN
 	if (message.middle.size() < 1) {
 		return join(sender_prefix, "431", sender->getNickname(), ERR_NONICKNAMEGIVEN());
 	}
 
 	std::string nickname = message.middle[0];
 
+	// nickname이 9자를 초과한 경우, 432 ERR_ERRONEUSNICKNAME
 	if (nickname.length() > 9) {
 		return join(sender_prefix, "432", nickname, ERR_ERRONEUSNICKNAME(nickname));
 	}
 	// TODO: 유효하지 않은 문자 예외 처리
 
+	// nickname이 이미 사용중인 경우, 433 ERR_NICKNAMEINUSE
 	std::map<int, User *> users = sender->getServer()->getUsers();
 	for (std::map<int, User *>::iterator it = users.begin(); it != users.end(); it++) {
 		if (it->second->getNickname() == nickname) {
@@ -21,7 +24,11 @@ std::string NICK(const Message &message, User *sender) {
 		}
 	}
 
+	// 기존 nickname을 nick_history에 추가하고, nickname을 업데이트
+	sender->reNewNickUpdateTime();
+	sender->addNickHistory(sender->getNickname(), sender->getNickUpdateTime());
 	sender->setNickname(nickname);
+
 	if (sender->getStatus() == NEED_NICKNAME) {
 		sender->setStatus(NEED_USERREGISTER);
 	}

--- a/src/Commands/TIME.cpp
+++ b/src/Commands/TIME.cpp
@@ -5,5 +5,5 @@ std::string TIME(const Message &message, User *sender) {
 	std::string	sender_prefix = sender->getServerPrefix();
 	std::string target = sender->getNickname();
 
-	return join(sender_prefix, "391", target, RPL_TIME(sender_prefix, sender->getServer()->currTime()));
+	return join(sender_prefix, "391", target, RPL_TIME(sender_prefix, currTime()));
 }

--- a/src/Commands/WHO.cpp
+++ b/src/Commands/WHO.cpp
@@ -58,7 +58,7 @@ std::string WHO(const Message &message, User *sender) {
 	std::map<std::string, Channel *> channels = server->getChannels();
 	for (std::map<std::string, Channel *>::iterator it = channels.begin(); it != channels.end(); it++) {
 		Channel *channel = it->second;
-		if (channel->getChannelname() == name) {
+		if (confirmMatch(name, channel->getChannelname())) {
 			std::set<int> user_fds = channel->getUsers();
 			for (std::set<int>::iterator it = user_fds.begin(); it != user_fds.end(); it++) {
 				User *target_user = server->getUserByFd(*it);
@@ -78,14 +78,16 @@ std::string WHO(const Message &message, User *sender) {
 		}
 	}
 
-	// name과 일치하는 채널이 없으면 서버에서 hostname or realname or nickname과 일치하는 유저들을 응답한다.
+	// name과 일치하는 채널이 없으면 서버에서 hostname or realname or nickname과 패턴이 일치하는 유저들을 응답한다.
 	std::map<int, User *> users = server->getUsers();
 	for (std::map<int, User *>::iterator it = users.begin(); it != users.end(); it++) {
 		User *target_user = it->second;
 		if (is_op && !(target_user->getMode() & FLAG_USER_O)) {
 			continue;
 		}
-		if (target_user->getHostname() == name || target_user->getRealname() == name || target_user->getNickname() == name) {
+			if (confirmMatch(name, target_user->getHostname())
+			|| confirmMatch(name, target_user->getRealname())
+			|| confirmMatch(name, target_user->getNickname())) {
 			// 352 RPL_WHOREPLY
 			server->sendMsg(
 				join(sender_prefix, "352", sender->getNickname(),

--- a/src/Commands/WHO.cpp
+++ b/src/Commands/WHO.cpp
@@ -1,0 +1,99 @@
+#include "../../include/Utils.hpp"
+
+bool isInSameChannel(const std::set<std::string> &channels, const std::set<std::string> &target_channels) {
+	std::vector<std::string> common_channels;
+	std::set_intersection(channels.begin(), channels.end(),
+	target_channels.begin(), target_channels.end(),
+	std::back_inserter(common_channels));
+	if (common_channels.size() > 0) {
+		return true;
+	}
+	return false;
+}
+
+std::string WHO(const Message &message, User *sender) {
+	std::string sender_prefix = sender->getServerPrefix();
+	Server *server = sender->getServer();
+
+	// name이 주어지지 않았거나 '0'이나 '*'로 주어진 경우 모든 visible한 리스트를 보여준다.
+	// 1. 서버에 존재하는 모든 채널을 하나씩 확인한다.
+	// 2. 채널에 속한 유저를 하나씩 확인한다.
+	// 3. sender와 공통 채널이 있는지를 확인한다.
+	// 4. sender와 공통 채널이 없고, +i user mode가 아니라면 visible한 유저이다.
+	// 5. visible한 유저의 정보를 RPL_WHOREPLY로 응답한다.
+	if (message.middle.size() < 1 || (message.middle.size() == 1 && (message.middle[0] == "*" || message.middle[0] == "0"))) {
+		std::map<std::string, Channel *> channels = server->getChannels();
+		for (std::map<std::string, Channel *>::iterator it = channels.begin(); it != channels.end(); it++) {
+			Channel *channel = it->second;
+			std::set<int> user_fds = channel->getUsers();
+			for (std::set<int>::iterator it = user_fds.begin(); it != user_fds.end(); it++) {
+				User *target_user = server->getUserByFd(*it);
+				if (isInSameChannel(sender->getJoinedChannels(), target_user->getJoinedChannels())) {
+					continue;
+				}
+				if (target_user->getMode() & FLAG_USER_I) {
+					continue;
+				}
+				// 352 RPL_WHOREPLY
+				server->sendMsg(
+					join(sender_prefix, "352", sender->getNickname(),
+					RPL_WHOREPLY(channel->getChannelname(), target_user->getUsername(),
+											target_user->getHostname(), target_user->getServerPrefix(),
+											target_user->getNickname(), target_user->getRealname())
+					), sender);
+			}
+		}
+		// 315 RPL_ENDOFWHO
+		return join(sender_prefix, "315", sender->getNickname(), RPL_ENDOFWHO("*"));
+	}
+
+	// 'o'가 주어진 경우 운영자만 매칭되도록 한다.
+	std::string name = message.middle[0];
+	bool is_op = false;
+	if (message.middle.size() == 2 && message.middle[1] == "o") {
+		is_op = true;
+	}
+
+	// name이 주어진 경우 name과 일치하는 패턴의 채널에 속한 유저들의 정보를 응답한다.
+	std::map<std::string, Channel *> channels = server->getChannels();
+	for (std::map<std::string, Channel *>::iterator it = channels.begin(); it != channels.end(); it++) {
+		Channel *channel = it->second;
+		if (channel->getChannelname() == name) {
+			std::set<int> user_fds = channel->getUsers();
+			for (std::set<int>::iterator it = user_fds.begin(); it != user_fds.end(); it++) {
+				User *target_user = server->getUserByFd(*it);
+				if (is_op && !(target_user->getMode() & FLAG_USER_O)) {
+					continue;
+				}
+				// 352 RPL_WHOREPLY
+				server->sendMsg(
+					join(sender_prefix, "352", sender->getNickname(),
+					RPL_WHOREPLY(channel->getChannelname(), target_user->getUsername(),
+											target_user->getHostname(), target_user->getServerPrefix(),
+											target_user->getNickname(), target_user->getRealname())
+					), sender);
+			}
+			// 315 RPL_ENDOFWHO
+			return join(sender_prefix, "315", sender->getNickname(), RPL_ENDOFWHO(name));
+		}
+	}
+
+	// name과 일치하는 채널이 없으면 서버에서 hostname or realname or nickname과 일치하는 유저들을 응답한다.
+	std::map<int, User *> users = server->getUsers();
+	for (std::map<int, User *>::iterator it = users.begin(); it != users.end(); it++) {
+		User *target_user = it->second;
+		if (is_op && !(target_user->getMode() & FLAG_USER_O)) {
+			continue;
+		}
+		if (target_user->getHostname() == name || target_user->getRealname() == name || target_user->getNickname() == name) {
+			// 352 RPL_WHOREPLY
+			server->sendMsg(
+				join(sender_prefix, "352", sender->getNickname(),
+				RPL_WHOREPLY("*", target_user->getUsername(),
+											target_user->getHostname(), target_user->getServerPrefix(),
+											target_user->getNickname(), target_user->getRealname())
+				), sender);
+		}
+	}
+	return join(sender_prefix, "315", sender->getNickname(), RPL_ENDOFWHO(name));
+}

--- a/src/Commands/WHOIS.cpp
+++ b/src/Commands/WHOIS.cpp
@@ -3,7 +3,7 @@
 void	WHOISONE(std::string sender_prefix, std::string nickname, User *sender, Server *server) {
 	std::map<int, User *> users = server->getUsers();
 	for (std::map<int, User *>::iterator it = users.begin(); it != users.end(); it++) {
-		if (it->second->getNickname() == nickname) {
+			if (confirmMatch(nickname, it->second->getNickname())) {
 			User *user = it->second;
 			std::string nickname = user->getNickname();
 			std::string hostname = user->getHostname();

--- a/src/Commands/WHOIS.cpp
+++ b/src/Commands/WHOIS.cpp
@@ -45,7 +45,7 @@ void	WHOISONE(std::string sender_prefix, std::string nickname, User *sender, Ser
 				), sender);
 
 			// 313 RPL_WHOISOPERATOR
-			if (it->second->getMode() & FLAG_CHANNEL_O) {
+			if (it->second->getMode() & FLAG_USER_O) {
 				server->sendMsg(
 					join(sender_prefix, "313", sender->getNickname(),
 					RPL_WHOISOPERATOR(nickname)

--- a/src/Commands/WHOIS.cpp
+++ b/src/Commands/WHOIS.cpp
@@ -1,14 +1,6 @@
 #include "../../include/Utils.hpp"
 
-std::string WHOIS(const Message &message, User *sender) {
-	std::string sender_prefix = sender->getServerPrefix();
-	Server *server = sender->getServer();
-
-	// nickname이 주어지지 않은 경우, 431 ERR_NONICKNAMEGIVEN
-	if (message.middle.size() < 1) {
-		return join(sender_prefix, "431", sender->getNickname(), ERR_NONICKNAMEGIVEN());
-	}
-	std::string nickname = message.middle[0];
+void	WHOISONE(std::string sender_prefix, std::string nickname, User *sender, Server *server) {
 	std::map<int, User *> users = server->getUsers();
 	for (std::map<int, User *>::iterator it = users.begin(); it != users.end(); it++) {
 		if (it->second->getNickname() == nickname) {
@@ -20,7 +12,7 @@ std::string WHOIS(const Message &message, User *sender) {
 
 			// 311 RPL_WHOISUSER
 			server->sendMsg(
-				join(sender_prefix, "311", nickname,
+				join(sender_prefix, "311", sender->getNickname(),
 				RPL_WHOISUSER(nickname, username, hostname, realname)
 				), sender);
 
@@ -32,7 +24,7 @@ std::string WHOIS(const Message &message, User *sender) {
 					channel_list += *it2 + " ";
 				}
 				server->sendMsg(
-					join(sender_prefix, "319", nickname,
+					join(sender_prefix, "319", sender->getNickname(),
 					RPL_WHOISCHANNELS(nickname, channel_list)
 					), sender);
 			}
@@ -42,38 +34,54 @@ std::string WHOIS(const Message &message, User *sender) {
 			+ std::string("Server started at ") + server->getStartTime();
 			// 312 RPL_WHOISSERVER
 			server->sendMsg(
-				join(sender_prefix, "312", nickname,
+				join(sender_prefix, "312", sender->getNickname(),
 				RPL_WHOISSERVER(nickname, server->getServername(), info)
 				), sender);
 
 			// 301 RPL_AWAY
 			server->sendMsg(
-				join(sender_prefix, "301", nickname,
-				RPL_AWAY(message.middle[0], "This is message from IRC server.")
+				join(sender_prefix, "301", sender->getNickname(),
+				RPL_AWAY(nickname, "This is message from IRC server.")
 				), sender);
 
 			// 313 RPL_WHOISOPERATOR
 			if (it->second->getMode() & FLAG_CHANNEL_O) {
 				server->sendMsg(
-					join(sender_prefix, "313", nickname,
+					join(sender_prefix, "313", sender->getNickname(),
 					RPL_WHOISOPERATOR(nickname)
 					), sender);
 			}
 			time_t cur_time = time(NULL);
 			// 317 RPL_WHOISIDLE
 			server->sendMsg(
-				join(sender_prefix, "317", nickname,
+				join(sender_prefix, "317", sender->getNickname(),
 				RPL_WHOISIDLE(nickname, static_cast<int>(difftime(cur_time, user->getLoginTime())))
 				), sender);
-
 			// 318 RPL_ENDOFWHOIS
 			server->sendMsg(
-				join(sender_prefix, "318", nickname,
+				join(sender_prefix, "318", sender->getNickname(),
 				RPL_ENDOFWHOIS(nickname)
 				), sender);
-			return std::string();
+		return ;
 		}
 	}
-	// nickname이 존재하지 않는 경우, 401 ERR_NOSUCHNICK
-	return join(sender_prefix, "401", nickname, ERR_NOSUCHNICK(nickname));
+	server->sendMsg(
+		join(sender_prefix, "401", sender->getNickname(),
+		ERR_NOSUCHNICK(nickname)
+		), sender);
+}
+
+std::string WHOIS(const Message &message, User *sender) {
+	std::string sender_prefix = sender->getServerPrefix();
+	Server *server = sender->getServer();
+
+	// nickname이 주어지지 않은 경우, 431 ERR_NONICKNAMEGIVEN
+	if (message.middle.size() < 1) {
+		return join(sender_prefix, "431", sender->getNickname(), ERR_NONICKNAMEGIVEN());
+	}
+	std::vector<std::string> nicknames = split(message.middle[0], ",");
+	for (std::vector<std::string>::iterator it = nicknames.begin(); it != nicknames.end(); it++) {
+		WHOISONE(sender_prefix, *it, sender, server);
+	}
+	return std::string();
 }

--- a/src/Commands/WHOIS.cpp
+++ b/src/Commands/WHOIS.cpp
@@ -46,21 +46,19 @@ std::string WHOIS(const Message &message, User *sender) {
 				RPL_WHOISSERVER(nickname, server->getServername(), info)
 				), sender);
 
-			// TODO: away message 추가 필요
 			// 301 RPL_AWAY
 			server->sendMsg(
 				join(sender_prefix, "301", nickname,
-				RPL_AWAY(message.middle[0], "Away message")
+				RPL_AWAY(message.middle[0], "This is message from IRC server.")
 				), sender);
 
-			// TODO: MODE 명령어 구현 후 추가
-			// // 313 RPL_WHOISOPERATOR
-			// if (it->second->getMode() & MODE_OPERATOR) {
-			// 	server->sendMsg(
-			// 		join(sender_prefix, "313", nickname,
-			// 		RPL_WHOISOPERATOR(nickname)
-			// 		), sender);
-			// }
+			// 313 RPL_WHOISOPERATOR
+			if (it->second->getMode() & FLAG_CHANNEL_O) {
+				server->sendMsg(
+					join(sender_prefix, "313", nickname,
+					RPL_WHOISOPERATOR(nickname)
+					), sender);
+			}
 			time_t cur_time = time(NULL);
 			// 317 RPL_WHOISIDLE
 			server->sendMsg(

--- a/src/Commands/WHOIS.cpp
+++ b/src/Commands/WHOIS.cpp
@@ -1,0 +1,81 @@
+#include "../../include/Utils.hpp"
+
+std::string WHOIS(const Message &message, User *sender) {
+	std::string sender_prefix = sender->getServerPrefix();
+	Server *server = sender->getServer();
+
+	// nickname이 주어지지 않은 경우, 431 ERR_NONICKNAMEGIVEN
+	if (message.middle.size() < 1) {
+		return join(sender_prefix, "431", sender->getNickname(), ERR_NONICKNAMEGIVEN());
+	}
+	std::string nickname = message.middle[0];
+	std::map<int, User *> users = server->getUsers();
+	for (std::map<int, User *>::iterator it = users.begin(); it != users.end(); it++) {
+		if (it->second->getNickname() == nickname) {
+			User *user = it->second;
+			std::string nickname = user->getNickname();
+			std::string hostname = user->getHostname();
+			std::string username = user->getUsername();
+			std::string realname = user->getRealname();
+
+			// 311 RPL_WHOISUSER
+			server->sendMsg(
+				join(sender_prefix, "311", nickname,
+				RPL_WHOISUSER(nickname, username, hostname, realname)
+				), sender);
+
+			// 참여중인 채널이 있는 경우, 319 RPL_WHOISCHANNELS
+			std::set<std::string> channels = user->getJoinedChannels();
+			if (channels.size() != 0) {
+				std::string channel_list = "";
+				for (std::set<std::string>::iterator it2 = channels.begin(); it2 != channels.end(); it2++) {
+					channel_list += *it2 + " ";
+				}
+				server->sendMsg(
+					join(sender_prefix, "319", nickname,
+					RPL_WHOISCHANNELS(nickname, channel_list)
+					), sender);
+			}
+
+			std::string info = std::string("\nThis is IRC server from Introversion-Relay-Chat\n")
+			+ std::string("Version is ") + server->getServerVersion() + std::string(".0\n")
+			+ std::string("Server started at ") + server->getStartTime();
+			// 312 RPL_WHOISSERVER
+			server->sendMsg(
+				join(sender_prefix, "312", nickname,
+				RPL_WHOISSERVER(nickname, server->getServername(), info)
+				), sender);
+
+			// TODO: away message 추가 필요
+			// 301 RPL_AWAY
+			server->sendMsg(
+				join(sender_prefix, "301", nickname,
+				RPL_AWAY(message.middle[0], "Away message")
+				), sender);
+
+			// TODO: MODE 명령어 구현 후 추가
+			// // 313 RPL_WHOISOPERATOR
+			// if (it->second->getMode() & MODE_OPERATOR) {
+			// 	server->sendMsg(
+			// 		join(sender_prefix, "313", nickname,
+			// 		RPL_WHOISOPERATOR(nickname)
+			// 		), sender);
+			// }
+			time_t cur_time = time(NULL);
+			// 317 RPL_WHOISIDLE
+			server->sendMsg(
+				join(sender_prefix, "317", nickname,
+				RPL_WHOISIDLE(nickname, static_cast<int>(difftime(cur_time, user->getLoginTime())))
+				), sender);
+
+			// 318 RPL_ENDOFWHOIS
+			server->sendMsg(
+				join(sender_prefix, "318", nickname,
+				RPL_ENDOFWHOIS(nickname)
+				), sender);
+			return std::string();
+		}
+	}
+	// nickname이 존재하지 않는 경우, 401 ERR_NOSUCHNICK
+	return join(sender_prefix, "401", nickname, ERR_NOSUCHNICK(nickname));
+}

--- a/src/Commands/WHOWAS.cpp
+++ b/src/Commands/WHOWAS.cpp
@@ -1,24 +1,73 @@
 #include "../../include/Utils.hpp"
 
+class UserName {
+	public:
+		UserName(std::string nickname, std::string username, std::string hostname, std::string realname) {
+			this->nickname = nickname;
+			this->username = username;
+			this->hostname = hostname;
+			this->realname = realname;
+		}
+		~UserName() {}
+
+		std::string nickname;
+		std::string username;
+		std::string hostname;
+		std::string realname;
+};
+
+bool comp(const std::pair<UserName *, time_t>& a, const std::pair<UserName *, time_t>& b) {
+	return a.second > b.second;
+};
+
 std::string WHOWAS(const Message &message, User *sender) {
 	std::string sender_prefix = sender->getServerPrefix();
 	Server *server = sender->getServer();
-  (void)sender;
-  (void)server;
+	(void)sender;
+	(void)server;
 
-  // nickname이 입력되지 않은 경우, 431 ERR_NONICKNAMEGIVEN
-  if (message.middle.size() < 1) {
-    return join(sender_prefix, "431", sender->getNickname(), ERR_NONICKNAMEGIVEN());
-  }
-  std::string nickname = message.middle[0];
+	// nickname이 입력되지 않은 경우, 431 ERR_NONICKNAMEGIVEN
+	if (message.middle.size() < 1) {
+		return join(sender_prefix, "431", sender->getNickname(), ERR_NONICKNAMEGIVEN());
+	}
+	std::string search_nickname = message.middle[0];
 
-  // TODO: 서버에 존재하는 모든 유저를 검색하여 nickname 히스토리를 확인하고, 그 중 nickname과 일치하는 값을 results에 저장.
-  // results에 저장된 값을 second에 대해 내림차순으로 정렬.
-  // 정렬 후 각각의 값에 대해 314 RPL_WHOWASUSER, 312 WHOISSERVER를 응답.
-  // 369 RPL_ENDOFWHOWAS를 마지막에 응답.
+	// 서버에 존재하는 모든 유저를 검색하여 nickname 히스토리를 확인하고, 그 중 search_nickname과 일치하는 값을 results에 저장.
+	std::map<int, User *> users = server->getUsers();
+	std::map<UserName *, time_t> results;
+	for (std::map<int, User *>::iterator it = users.begin(); it != users.end(); it++) {
+		std::map<std::string, time_t> nick_history = it->second->getNickHistory();
+		for (std::map<std::string, time_t>::iterator it2 = nick_history.begin(); it2 != nick_history.end(); it2++) {
+			if (it2->first == search_nickname) {
+				UserName *user = new UserName(it->second->getNickname(), it->second->getUsername(), it->second->getHostname(), it->second->getRealname());
+				results.insert(std::pair<UserName *, time_t>(user, it2->second));
+			}
+		}
+	}
 
+	// results를 second 기준으로 내림차순 정렬
+	std::vector<std::pair<UserName *, time_t> > sorted_results(results.begin(), results.end());
+	std::sort(sorted_results.begin(), sorted_results.end(), comp);
 
+	// nickname 히스토리가 존재하지 않는 경우, 401 ERR_NOSUCHNICK
+	if (results.size() == 0) {
+		return join(sender_prefix, "401", sender->getNickname(), ERR_NOSUCHNICK(search_nickname));
+	}
 
-  // nickname 히스토리가 존재하지 않는 경우, 401 ERR_NOSUCHNICK
-  return join(sender_prefix, "401", sender->getNickname(), ERR_NOSUCHNICK(nickname));
+	// 정렬된 결과를 순회하며 314 RPL_WHOWASUSER, 312 WHOISSERVER를 응답
+	for (std::vector<std::pair<UserName *, time_t> >::iterator it = sorted_results.begin(); it != sorted_results.end(); it++) {
+		// 314 RPL_WHOWASUSER
+		server->sendMsg(
+				join(sender_prefix, "314", it->first->nickname,
+				RPL_WHOWASUSER(it->first->nickname, it->first->username, it->first->hostname, it->first->realname)
+				), sender);
+		// 312 WHOISSERVER
+		server->sendMsg(
+				join(sender_prefix, "312", it->first->nickname,
+				RPL_WHOISSERVER(it->first->nickname, it->first->hostname, it->first->realname)
+				), sender);
+	}
+
+	// 369 RPL_ENDOFWHOWAS
+	return join(sender_prefix, "369", sender->getNickname(), RPL_ENDOFWHOWAS(search_nickname));
 }

--- a/src/Commands/WHOWAS.cpp
+++ b/src/Commands/WHOWAS.cpp
@@ -32,6 +32,14 @@ std::string WHOWAS(const Message &message, User *sender) {
 	}
 	std::string search_nickname = message.middle[0];
 
+	int count = INT_MAX;
+	if (message.middle.size() == 2) {
+		count = atoi(message.middle[1].c_str());
+		if (count < 0) {
+			count = INT_MAX;
+		}
+	}
+
 	// 서버에 존재하는 모든 유저를 검색하여 nickname 히스토리를 확인하고, 그 중 search_nickname과 일치하는 값을 results에 저장.
 	std::map<int, User *> users = server->getUsers();
 	std::map<UserName *, time_t> results;
@@ -55,7 +63,11 @@ std::string WHOWAS(const Message &message, User *sender) {
 	}
 
 	// 정렬된 결과를 순회하며 314 RPL_WHOWASUSER, 312 WHOISSERVER를 응답
+	int i = 0;
 	for (std::vector<std::pair<UserName *, time_t> >::iterator it = sorted_results.begin(); it != sorted_results.end(); it++) {
+		if (i >= count) {
+			break;
+		}
 		// 314 RPL_WHOWASUSER
 		server->sendMsg(
 				join(sender_prefix, "314", it->first->nickname,
@@ -66,6 +78,7 @@ std::string WHOWAS(const Message &message, User *sender) {
 				join(sender_prefix, "312", it->first->nickname,
 				RPL_WHOISSERVER(it->first->nickname, it->first->hostname, it->first->realname)
 				), sender);
+		++i;
 	}
 
 	// 369 RPL_ENDOFWHOWAS

--- a/src/Commands/WHOWAS.cpp
+++ b/src/Commands/WHOWAS.cpp
@@ -1,0 +1,24 @@
+#include "../../include/Utils.hpp"
+
+std::string WHOWAS(const Message &message, User *sender) {
+	std::string sender_prefix = sender->getServerPrefix();
+	Server *server = sender->getServer();
+  (void)sender;
+  (void)server;
+
+  // nickname이 입력되지 않은 경우, 431 ERR_NONICKNAMEGIVEN
+  if (message.middle.size() < 1) {
+    return join(sender_prefix, "431", sender->getNickname(), ERR_NONICKNAMEGIVEN());
+  }
+  std::string nickname = message.middle[0];
+
+  // TODO: 서버에 존재하는 모든 유저를 검색하여 nickname 히스토리를 확인하고, 그 중 nickname과 일치하는 값을 results에 저장.
+  // results에 저장된 값을 second에 대해 내림차순으로 정렬.
+  // 정렬 후 각각의 값에 대해 314 RPL_WHOWASUSER, 312 WHOISSERVER를 응답.
+  // 369 RPL_ENDOFWHOWAS를 마지막에 응답.
+
+
+
+  // nickname 히스토리가 존재하지 않는 경우, 401 ERR_NOSUCHNICK
+  return join(sender_prefix, "401", sender->getNickname(), ERR_NOSUCHNICK(nickname));
+}

--- a/src/NumericReplies.cpp
+++ b/src/NumericReplies.cpp
@@ -131,6 +131,8 @@ std::string RPL_ENDOFNAMES(const std::string &channel) {
 // 369
 std::string RPL_ENDOFWHOWAS(const std::string &nickname) {
 	return nickname + " :End of WHOWAS";
+}
+
 // 367
 std::string RPL_BANLIST(const std::string &channel, const std::string &banmask) {
 	return channel + " " + banmask;//"<channel> <banid>"

--- a/src/NumericReplies.cpp
+++ b/src/NumericReplies.cpp
@@ -45,6 +45,11 @@ std::string RPL_WHOWASUSER(const std::string &nickname, const std::string &usern
 	return nickname + " " + username + " " + hostname + " * :" + realname;
 }
 
+// 315
+std::string RPL_ENDOFWHO(const std::string &name) {
+	return name + " :End of /WHO list";
+}
+
 // 317
 std::string RPL_WHOISIDLE(const std::string &nickname, int seconds) {
 	std::stringstream ss;
@@ -96,6 +101,11 @@ std::string RPL_INVITING(const std::string &channel, const std::string &nickname
 // 351
 std::string RPL_VERSION(const std::string &version, const std::string &debuglevel, const std::string &server, const std::string &comments) {
 	return version + "." + debuglevel + " " + server + " :" + comments;
+}
+
+// 352
+std::string RPL_WHOREPLY(const std::string &channel, const std::string &user, const std::string &host, const std::string &server, const std::string &nickname, const std::string &realname) {
+	return channel + " " + user + " " + host + " " + server + " " + nickname + " " + realname;
 }
 
 // 353

--- a/src/NumericReplies.cpp
+++ b/src/NumericReplies.cpp
@@ -35,6 +35,11 @@ std::string RPL_WHOISSERVER(const std::string &nickname, const std::string &serv
 	return nickname + " " + server + " :" + server_info;
 }
 
+// 314
+std::string RPL_WHOWASUSER(const std::string &nickname, const std::string &username, const std::string &hostname, const std::string &realname) {
+	return nickname + " " + username + " " + hostname + " * :" + realname;
+}
+
 // 317
 std::string RPL_WHOISIDLE(const std::string &nickname, int seconds) {
 	std::stringstream ss;
@@ -96,6 +101,11 @@ std::string RPL_NAMREPLY(const std::string &channel, const std::string &userlist
 // 366
 std::string RPL_ENDOFNAMES(const std::string &channel) {
 	return channel + " :End of /NAMES list";
+}
+
+// 369
+std::string RPL_ENDOFWHOWAS(const std::string &nickname) {
+	return nickname + " :End of WHOWAS";
 }
 
 // 371

--- a/src/NumericReplies.cpp
+++ b/src/NumericReplies.cpp
@@ -25,6 +25,34 @@ std::string RPL_AWAY(const std::string &nickname, const std::string &message) {
 	return nickname + " :" + message;
 }
 
+// 311
+std::string RPL_WHOISUSER(const std::string &nickname, const std::string &username, const std::string &hostname, const std::string &realname) {
+	return nickname + " " + username + " " + hostname + " * :" + realname;
+}
+
+// 312
+std::string RPL_WHOISSERVER(const std::string &nickname, const std::string &server, const std::string &server_info) {
+	return nickname + " " + server + " :" + server_info;
+}
+
+// 317
+std::string RPL_WHOISIDLE(const std::string &nickname, int seconds) {
+	std::stringstream ss;
+	ss << seconds;
+	std::string seconds_str = ss.str();
+	return nickname + " " + seconds_str + " :seconds idle";
+}
+
+// 318
+std::string RPL_ENDOFWHOIS(const std::string &nickname) {
+	return nickname + " :End of /WHOIS list";
+}
+
+// 319
+std::string RPL_WHOISCHANNELS(const std::string &nickname, const std::string &channels) {
+	return nickname + " :" + channels;
+}
+
 // 321
 std::string RPL_LISTSTART(void) {
 	return "Channel :Topic";

--- a/src/NumericReplies.cpp
+++ b/src/NumericReplies.cpp
@@ -35,6 +35,11 @@ std::string RPL_WHOISSERVER(const std::string &nickname, const std::string &serv
 	return nickname + " " + server + " :" + server_info;
 }
 
+// 313
+std::string RPL_WHOISOPERATOR(const std::string &nickname) {
+	return nickname + " :is an IRC operator";
+}
+
 // 314
 std::string RPL_WHOWASUSER(const std::string &nickname, const std::string &username, const std::string &hostname, const std::string &realname) {
 	return nickname + " " + username + " " + hostname + " * :" + realname;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -20,6 +20,7 @@ Server::Server(std::string port, std::string password) {
 	_executor[std::string("ADMIN")] = ADMIN;
 	_executor[std::string("INFO")] = INFO;
 	_executor[std::string("KILL")] = KILL;
+	_executor[std::string("WHOIS")] = WHOIS;
 	_servername = SERVER_NAME;
 	_server_version = SERVER_VERSION;
 	_start_time = currTime();
@@ -73,18 +74,6 @@ std::string Server::getServerVersion(void) {
 
 std::string Server::getStartTime(void) {
 	return _start_time;
-}
-
-std::string Server::currTime(void) {
-	time_t curr_time;
-	struct tm *local_time;
-	std::string local_time_str;
-
-	time(&curr_time);
-	local_time = localtime(&curr_time);
-	local_time_str = asctime(local_time);
-	local_time_str.erase(--local_time_str.end());
-	return local_time_str;
 }
 
 void Server::run(bool &stop) {

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -21,6 +21,7 @@ Server::Server(std::string port, std::string password) {
 	_executor[std::string("INFO")] = INFO;
 	_executor[std::string("KILL")] = KILL;
 	_executor[std::string("WHOIS")] = WHOIS;
+	_executor[std::string("WHOWAS")] = WHOWAS;
 	_servername = SERVER_NAME;
 	_server_version = SERVER_VERSION;
 	_start_time = currTime();

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -20,6 +20,7 @@ Server::Server(std::string port, std::string password) {
 	_executor[std::string("ADMIN")] = ADMIN;
 	_executor[std::string("INFO")] = INFO;
 	_executor[std::string("KILL")] = KILL;
+	_executor[std::string("WHO")] = WHO;
 	_executor[std::string("WHOIS")] = WHOIS;
 	_executor[std::string("WHOWAS")] = WHOWAS;
 	_executor[std::string("PRIVMSG")] = PRIVMSG;
@@ -79,6 +80,10 @@ std::string Server::getServerVersion(void) {
 
 std::string Server::getStartTime(void) {
 	return _start_time;
+}
+
+User	*Server::getUserByFd(int fd) {
+	return _users[fd];
 }
 
 void Server::run(bool &stop) {

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -204,6 +204,10 @@ void Server::runCommand(const Message &message, User *user) {
 	else {
 		sendMsg(join(user->getServer()->getServername(), "421", user->getNickname(), ERR_UNKNOWNCOMMAND(message.command)), user);
 	}
+	if (DEBUG) {
+		std::cout << "nickname: " << user->getNickname() << std::endl;
+		std::cout << user->getNickHistory() << std::endl;
+	}
 }
 
 void Server::sendMsg(const std::string &message, User *user) {
@@ -252,5 +256,13 @@ void Server::killUser(User *user) {
 		part_message.middle.pop_back();
 	}
 	user->setStatus(DELETE);
+
+	user->reNewNickUpdateTime();
+	user->addNickHistory(user->getNickname(), user->getNickUpdateTime());
+	user->setNickname("*");
+	if (DEBUG) {
+		std::cout << "nickname: " << user->getNickname() << std::endl;
+		std::cout << user->getNickHistory() << std::endl;
+	}
 	_quitters.push_back(user->getUserSocket());
 }

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -8,6 +8,7 @@ User::User(int user_socket, std::string hostname, Server *server) {
 	_hostname = hostname;
 	_realname = "";
 	_login_time = time(NULL);
+	_nick_update_time = time(NULL);
 }
 
 User::~User() {
@@ -29,6 +30,7 @@ std::string User::getNickname(void) {
 void User::setNickname(std::string nickname) {
 	_nickname = nickname;
 }
+
 
 std::string User::getUsername(void) {
 	return _username;
@@ -94,12 +96,28 @@ std::set<std::string> User::getJoinedChannels(void) {
 	return _joined;
 }
 
-void User::joinChannel(std::string channel_name){
+void User::joinChannel(std::string channel_name) {
 	_joined.insert(channel_name);
 }
 
-void User::leaveChannel(std::string channel_name){
+void User::leaveChannel(std::string channel_name) {
 	_joined.erase(channel_name);
+}
+
+std::map<std::string, time_t>	User::getNickHistory(void) {
+	return _nick_history;
+}
+
+void		User::addNickHistory(std::string nickname, time_t nick_update_time) {
+	_nick_history.insert(std::pair<std::string, time_t>(nickname, nick_update_time));
+}
+
+time_t	User::getNickUpdateTime(void) {
+	return _nick_update_time;
+}
+
+void		User::reNewNickUpdateTime(void) {
+	_nick_update_time = time(NULL);
 }
 
 void		User::printStatus(void) {

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -7,6 +7,7 @@ User::User(int user_socket, std::string hostname, Server *server) {
 	_server = server;
 	_hostname = hostname;
 	_realname = "";
+	_login_time = time(NULL);
 }
 
 User::~User() {
@@ -41,12 +42,20 @@ std::string	User::getHostname(void) {
 	return _hostname;
 }
 
+void		User::setHostname(std::string hostname) {
+	_hostname = hostname;
+}
+
 std::string	User::getRealname(void) {
 	return _realname;
 }
 
 void		User::setRealname(std::string realname) {
 	_realname = realname;
+}
+
+time_t User::getLoginTime(void) {
+	return _login_time;
 }
 
 int User::getMode(void) {

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -44,6 +44,14 @@ std::ostream& operator<<(std::ostream& os, const Message& message) {
 	return os;
 }
 
+std::ostream& operator<<(std::ostream& os, const std::map<std::string, time_t>& nick_history) {
+	std::cout << "nickname history: " << std::endl;
+	for (std::map<std::string, time_t>::const_iterator pn = nick_history.begin(); pn != nick_history.end(); pn++) {
+		os << "|" << pn->first << "|" << " update_time: " << pn->second << std::endl;
+	}
+	return os;
+}
+
 std::string currTime(void) {
 	time_t curr_time;
 	struct tm *local_time;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -128,9 +128,6 @@ bool checkMask(std::set<std::string> banlist, std::string prefix) {
 	std::string bannick;
 	std::string banuser;
 
-	std::cout << "user: " << user << std::endl;
-	std::cout << "nickname: " << nickname << std::endl;
-	std::cout << "username: " << username << std::endl;
 	for (std::set<std::string>::iterator it = banlist.begin();it != banlist.end();it++) {
 		bannick = (*it).substr(0, (*it).find("!", 0));
 		banuser = (*it).substr((*it).find("!", 0) + 1);

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -43,3 +43,15 @@ std::ostream& operator<<(std::ostream& os, const Message& message) {
 	os << "trailing: " << "|" << message.trailing << "|" << std::endl;
 	return os;
 }
+
+std::string currTime(void) {
+	time_t curr_time;
+	struct tm *local_time;
+	std::string local_time_str;
+
+	time(&curr_time);
+	local_time = localtime(&curr_time);
+	local_time_str = asctime(local_time);
+	local_time_str.erase(--local_time_str.end());
+	return local_time_str;
+}

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -63,39 +63,62 @@ std::string currTime(void) {
 	local_time_str.erase(--local_time_str.end());
 	return local_time_str;
 }
-bool isIncluded(std::string ban, std::string user) {
-	size_t u = 0, i = 0;
 
-	while (i < ban.length()) {
-		if (ban[i] == '*') {
-			while (++i < ban.length()) {
-				if (!(ban[i] == '*' || ban[i] == '?')) {
-					break;
-				}
-			}
-			if (i == ban.length()) {
+// bool isIncluded(std::string pattern, std::string target) {
+// 	size_t u = 0, i = 0;
+
+// 	while (i < pattern.length()) {
+// 		if (pattern[i] == '*') {
+// 			while (++i < pattern.length()) {
+// 				if (!(pattern[i] == '*' || pattern[i] == '?')) {
+// 					break;
+// 				}
+// 			}
+// 			if (i == pattern.length()) {
+// 				return true;
+// 			}
+// 			while (pattern[i] != target[u]) {
+// 				if (u == target.length()) {
+// 					return false;
+// 				}
+// 				u++;
+// 			}
+// 		} else if (pattern[i] == '?') {
+// 			if (u == target.length()) {
+// 				return false;
+// 			}
+// 			u++;
+// 		} else {
+// 			if (u == target.length() || pattern[i] != target[u]) {
+// 				return false;
+// 			}
+// 			u++;
+// 		}
+// 		i++;
+// 	}
+// 	return true;
+// }
+
+bool confirmMatch(std::string pattern, std::string target) {
+	size_t cur = 0;
+	while (cur < target.length() && cur < pattern.length()
+	&& (pattern[cur] == '?' || pattern[cur] == target[cur])) {
+		++cur;
+	}
+
+	if (cur == pattern.length()) {
+		return cur == target.size();
+	}
+
+	if (pattern[cur] == '*') {
+		for (size_t i = 0; cur + i <= target.length(); ++i)
+		{
+			if (confirmMatch(pattern.substr(cur + 1), target.substr(cur + i))) {
 				return true;
 			}
-			while (ban[i] != user[u]) {
-				if (u == user.length()) {
-					return false;
-				}
-				u++;
-			}
-		} else if (ban[i] == '?') {
-			if (u == user.length()) {
-				return false;
-			}
-			u++;
-		} else {
-			if (u == user.length() || ban[i] != user[u]) {
-				return false;
-			}
-			u++;
 		}
-		i++;
 	}
-	return true;
+	return false;
 }
 
 bool checkMask(std::set<std::string> banlist, std::string prefix) {
@@ -105,10 +128,14 @@ bool checkMask(std::set<std::string> banlist, std::string prefix) {
 	std::string bannick;
 	std::string banuser;
 
+	std::cout << "user: " << user << std::endl;
+	std::cout << "nickname: " << nickname << std::endl;
+	std::cout << "username: " << username << std::endl;
 	for (std::set<std::string>::iterator it = banlist.begin();it != banlist.end();it++) {
 		bannick = (*it).substr(0, (*it).find("!", 0));
 		banuser = (*it).substr((*it).find("!", 0) + 1);
-		if (isIncluded(bannick, nickname) && isIncluded(banuser, banuser)) {
+		if (confirmMatch(bannick, nickname) && confirmMatch(bannick, username)) {
+		// if (isIncluded(bannick, nickname) && isIncluded(banuser, banuser)) {
 			return true;
 		}
 	}


### PR DESCRIPTION
## WHOIS

이 메세지는 특정 유저의 정보를 알고싶을 때 사용합니다.
서버는 여러 numeric replies 로 해당 유저에 관한 정보를 응답합니다.
comma 로 구분된 여러 nickname 들의 리스트가 주어질 수 있습니다.
특정 서버를 입력할 수도 있지만 서버 간 통신을 다루지 않으므로 정의되지 않은 동작으로 간주합니다.

- nickname이 주어지지 않은 경우, `431 ERR_NONICKNAMEGIVEN`를 응답합니다.

콤마를 기준으로 split하여 nickname vector를 생성하고 반복문으로 유저 각각에 대해 WHOIS 명령을 수행합니다. (코드 상에서는 WHOISONE 함수 실행)

- 유저가 서버에 존재하는 경우, 해당 유저의 정보를 `311 RPL_WHOISUSER`를 통해 응답합니다.
- 해당 유저가 참여중인 채널이 있는 경우, 해당 채널의 정보를 `319 RPL_WHOISCHANNELS`을 통해 응답합니다.
- `312 RPL_WHOISSERVER`을 통해 서버 정보를 응답합니다.
- `301 RPL_AWAY`을 통해 away message를 응답합니다.
- 서버 관리자인 경우 `313 RPL_WHOISOPERATOR`를 응답합니다.
- 해당 유저가 유휴 상태에 진입한 시간(현재 시간 - 로그인 시간으로 계산함)을 `317 RPL_WHOISIDLE`로 응답합니다.
- `318 RPL_ENDOFWHOIS`를 응답합니다.
- 해당 유저가 서버에 존재하지 않는 경우 `401 ERR_NOSUCHNICK`를 응답합니다.

<br>

## WHOWAS

Whowas 는 더 이상 존재하지 않는 nickname 에 대한 정보를 요구하는 명령어입니다.
nickname 이 변경되었거나 IRC 에서 나갔을 경우(PING에 응답하지 않은 경우) 여기에 속합니다.

서버는 주어진 nickname 과 lexically same (여기선 wild card 사용불가) 인 nickname의 히스토리를 찾습니다.

제일 최근 내역부터 반환하며(가장 최근에 해당 닉네임을 소유한 유저 순서) count 가 양수로 주어진 경우 count 갯수만큼만 반환하고 count 가 음수거나 주어지지 않은 경우 전부 반환합니다.

- nickname이 입력되지 않은 경우, `431 ERR_NONICKNAMEGIVEN`를 응답합니다.
서버에 존재하는 모든 유저를 검색하여 nickname 히스토리를 확인하고, 그 중 search_nickname과 일치하는 값을 results에 저장합니다.
- nickname 히스토리가 존재하지 않는 경우, `401 ERR_NOSUCHNICK`를 응답합니다.
results를 second(닉네임 변경 시간) 기준으로 내림차순 정렬합니다.
- 정렬된 결과를 순회하며 `314 RPL_WHOWASUSER`, `312 WHOISSERVER`를 응답합니다.
- `369 RPL_ENDOFWHOWAS`를 응답합니다.

<br>

## WHO

name이 주어지지 않았거나 `'0'`이나 `'*'`로 주어진 경우 모든 `visible`한 리스트를 보여줍니다.

### 인자를 주지 않은 경우
1. 서버에 존재하는 모든 채널을 하나씩 확인한다.
2. 채널에 속한 유저를 하나씩 확인한다.
3. sender와 공통 채널이 있는지를 확인한다.
4. sender와 공통 채널이 없고, +i user mode가 아니라면 visible한 유저이다.
5. visible한 유저의 정보를 RPL_WHOREPLY로 응답한다.

### 인자를 준 경우
`'o'`가 주어진 경우 운영자만 매칭되도록 한다.
name이 주어진 경우 name과 일치하는 패턴의 채널에 속한 유저들의 정보를 응답한다.

name과 일치하는 채널이 없으면 서버에서 hostname or realname or nickname과 일치하는 유저들을 응답한다.

### 응답
에러 응답은 만 존재하나 서버에 서버 통신 상황에서 사용되므로 사용하지 않았습니다.

성공 응답은 `352 RPL_WHOREPLY`(응답 내용)와 `315 RPL_ENDOFWHO`(응답 종료 알림)으로만 이루져있습니다.

<br>

## TODO

1. `WHOWAS`의 경우 mask(정규표현식)을 사용할 수 없지만 `WHO`, `WHOIS`는 mask가 입력값으로 들어올 수 있습니다.
이부분은 mask 관련 기능이 구현되면 수정하겠습니다.
2. `PING`에 걸린 상태에서 `NICK` 명령어를 수행하면 `REGISTERED` 상태가 되는 버그가 존재합니다. 관련해서 버그가 자주 생기는 것 같아 근본적으로 문제를 해결할 필요가 있어보입니다. `PING`에 걸린 상태에서 명령어를 치면 `REGISTERED`가 되게 대신 걸리기 직전 상태를 기억해두었다가 해당 상태로 되돌아가게 만드는게 더 적절하다고 느껴지네요..! 관련해서는 따로 이슈를 파도록 하겠습니다.
