### PR TITLE
mode b 구현 (+아래 MODE 버그 수정 #42에 이어서 구현함)

### DIFF
--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -18,6 +18,7 @@ class Channel {
 		int						_mode;
 		std::set<int>			_users;
 		std::set<int>			_invited;
+		std::set<std::string>	_banlist;
 
 	public:
 		Channel(std::string channelname, User *user);
@@ -41,6 +42,9 @@ class Channel {
 		std::set<int>			getInvited(void);
 		std::string				getUserList(User *user);
 		int						getVisibleUsers(User *user);
+		std::set<std::string>	getBanList(void);
+		void					setBanMask(std::string mask);
+		void					removeBanMask(std::string mask);
 
 		void					addUser(User *user);
 		void					removeUser(User *user);

--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -69,6 +69,7 @@ std::vector<std::string>	split(std::string str, std::string delimiter);
 std::string					join(std::string sender_prefix, std::string code, std::string target, std::string message);
 std::string					toString(int var);
 std::ostream& operator<<(std::ostream& os, const Message& message);
+bool						checkMask(std::set<std::string> banlist, std::string host);
 
 // Commands
 std::string PASS(const Message &message, User *sender);

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -111,6 +111,20 @@ int Channel::getVisibleUsers(User *user) {
 	return size;
 }
 
+std::set<std::string> Channel::getBanList(void) {
+	return _banlist;
+}
+
+void Channel::setBanMask(std::string mask) {
+	_banlist.insert(mask);
+}
+
+void Channel::removeBanMask(std::string mask) {
+	if (_banlist.find(mask) != _banlist.end()) {
+		_banlist.erase(mask);
+	}
+}
+
 void Channel::addUser(User *user) {
 	_users.insert(user->getUserSocket());
 }

--- a/src/Commands/JOIN.cpp
+++ b/src/Commands/JOIN.cpp
@@ -48,14 +48,16 @@ std::string JOIN(const Message &message, User *sender) {
 			}
 		}
 
-		/*
+		
 		// 2. nick/username/hostname not in active bans.
 		// ERR_BANNEDFROMCHAN
-		std::set<int> banlist = channel->getBanlist();
-		if (channel->getModes & FLAG_CHANNEL_B)
-			if (banlist.find(sender->getUserSocket()) != banlist.end())
-				return join(sender->getServerPrefix(), "474", sender->getNickname(), message);
-		*/
+		std::set<std::string> banlist = channel->getBanList();
+		if (channel->getMode() & FLAG_CHANNEL_B) {
+			if (checkMask(banlist, sender->getUserPrefix())) {
+				sender->getServer()->sendMsg(join(sender_prefix, "474", target, ERR_BANNEDFROMCHAN(channels[i])), sender);
+				continue ;
+			}
+		}
 
 		// 3. passowrd if needed
 		// ERR_BADCHANNELKEY

--- a/src/Commands/MODE.cpp
+++ b/src/Commands/MODE.cpp
@@ -142,11 +142,13 @@ std::string MODE(const Message &message, User *sender) {
 						if (message.middle.size() < 3)
 							sender->getServer()->sendMsg(join(sender_prefix, "461", target, ERR_NEEDMOREPARAMS(message.command)), sender);
 						// ERR_KEYSET
-						if (channel->getKey().length() > 0) {
+						else if (channel->getKey().length() > 0) {
 							sender->getServer()->sendMsg(join(sender_prefix, "467", target, ERR_KEYSET(name)), sender);
 						}
-						channel->setKey(message.middle[2]);
-						channel->setMode(channel->getMode() | FLAG_CHANNEL_K);
+						else {
+							channel->setKey(message.middle[2]);
+							channel->setMode(channel->getMode() | FLAG_CHANNEL_K);
+						}
 					}
 					else if (sign == '-') {
 						channel->setKey("");
@@ -157,34 +159,34 @@ std::string MODE(const Message &message, User *sender) {
 		
 		}
 		// RPL_CHANNELMODEIS opsitnlbk
-		if (user->getMode() | FLAG_CHANNEL_O) {
+		if (channel->getMode() & FLAG_CHANNEL_O) {
 			mode += "o";
 			mode_params += "o: <operator>";
 		}
-		if (user->getMode() | FLAG_CHANNEL_P) {
+		if (channel->getMode() & FLAG_CHANNEL_P) {
 			mode += "p";
 		}
-		if (user->getMode() | FLAG_CHANNEL_S) {
+		if (channel->getMode() & FLAG_CHANNEL_S) {
 			mode += "s";
 		}
-		if (user->getMode() | FLAG_CHANNEL_I) {
+		if (channel->getMode() & FLAG_CHANNEL_I) {
 			mode += "i";
 		}
-		if (user->getMode() | FLAG_CHANNEL_T) {
+		if (channel->getMode() & FLAG_CHANNEL_T) {
 			mode += "t";
 		}
-		if (user->getMode() | FLAG_CHANNEL_N) {
+		if (channel->getMode() & FLAG_CHANNEL_N) {
 			mode += "n";
 		}
-		if (user->getMode() | FLAG_CHANNEL_B) {
+		if (channel->getMode() & FLAG_CHANNEL_B) {
 			mode += "b";
 			mode_params += "b: <banmask>";
 		}
-		if (user->getMode() | FLAG_CHANNEL_L) {
+		if (channel->getMode() & FLAG_CHANNEL_L) {
 			mode += "l";
 			mode_params += "l: " + toString(channel->getLimit()) + " ";
 		}
-		if (user->getMode() | FLAG_CHANNEL_K) {
+		if (channel->getMode() & FLAG_CHANNEL_K) {
 			mode += "k";
 			mode_params += "k: " + channel->getKey() + " ";
 		}
@@ -226,10 +228,10 @@ std::string MODE(const Message &message, User *sender) {
 			}
 		}
 		// RPL_UMODEIS
-		if (user->getMode() | FLAG_USER_I) {
+		if (user->getMode() & FLAG_USER_I) {
 			mode += "i";
 		}
-		if (user->getMode() | FLAG_USER_O) {
+		if (user->getMode() & FLAG_USER_O) {
 			mode += "o";
 		}
 		return join(sender_prefix, "221", target, RPL_UMODEIS(mode));

--- a/src/Commands/MODE.cpp
+++ b/src/Commands/MODE.cpp
@@ -63,20 +63,22 @@ std::string MODE(const Message &message, User *sender) {
 			switch (flags[i]) {
 				case 'o':
 					// ERR_NEEDMOREPARAMS
-					if (message.middle.size() < 3)
+					if (message.middle.size() < 3) {
 						sender->getServer()->sendMsg(join(sender_prefix, "461", target, ERR_NEEDMOREPARAMS(message.command)), sender);
-					user = sender->getServer()->getUserByName(message.middle[2]);
-					// ERR_NOSUCHNICK
-					if (!user || !channel->checkOnChannel(user)) {
-						return join(sender_prefix, "401", target, ERR_NOSUCHNICK(message.middle[2]));
-					}
-					if (sign == '+') {
-						channel->addOperator(user);
-						channel->setMode(channel->getMode() | FLAG_CHANNEL_O);
-					}
-					else if (sign == '-') {
-						channel->removeOperator(user);
-						channel->setMode(channel->getMode() & ~FLAG_CHANNEL_O);
+					} else {
+						user = sender->getServer()->getUserByName(message.middle[2]);
+						// ERR_NOSUCHNICK
+						if (!user || !channel->checkOnChannel(user)) {
+							return join(sender_prefix, "401", target, ERR_NOSUCHNICK(message.middle[2]));
+						}
+						if (sign == '+') {
+							channel->addOperator(user);
+							channel->setMode(channel->getMode() | FLAG_CHANNEL_O);
+						}
+						else if (sign == '-') {
+							channel->removeOperator(user);
+							channel->setMode(channel->getMode() & ~FLAG_CHANNEL_O);
+						}
 					}
 					break ;
 				case 'p':
@@ -122,10 +124,12 @@ std::string MODE(const Message &message, User *sender) {
 				case 'l':
 					if (sign == '+') {
 						// ERR_NEEDMOREPARAMS
-						if (message.middle.size() < 3)
+						if (message.middle.size() < 3) {
 							sender->getServer()->sendMsg(join(sender_prefix, "461", target, ERR_NEEDMOREPARAMS(message.command)), sender);
-						channel->setLimit(atoi(message.middle[2].c_str()));
-						channel->setMode(channel->getMode() | FLAG_CHANNEL_L);
+						} else {
+							channel->setLimit(atoi(message.middle[2].c_str()));
+							channel->setMode(channel->getMode() | FLAG_CHANNEL_L);
+						}
 					}
 					else if (sign == '-') {
 						channel->setLimit(DEFAULT_LIMIT);
@@ -133,14 +137,37 @@ std::string MODE(const Message &message, User *sender) {
 					}
 					break ;
 				case 'b':
-           			// RPL_BANLIST                     
-		   			// RPL_ENDOFBANLIST
+           			if (sign == '+') {
+						if (message.middle.size() < 2) {
+							return join(sender_prefix, "461", target, ERR_NEEDMOREPARAMS(message.command));
+						}
+						if (message.middle.size() < 3) {
+							// RPL_BANLIST
+							std::set<std::string> banlist = channel->getBanList();
+							for (std::set<std::string>::iterator it = banlist.begin();it != banlist.end();it++) {
+								sender->getServer()->sendMsg(join(sender_prefix, "367", target, RPL_BANLIST(name, *it)), sender);
+							}
+							// RPL_ENDOFBANLIST
+							sender->getServer()->sendMsg(join(sender_prefix, "368", target, RPL_ENDOFBANLIST(name)), sender);
+						} else {
+							channel->setBanMask(message.middle[2]);
+							channel->setMode(channel->getMode() | FLAG_CHANNEL_B);
+						}
+					}
+					else if (sign == '-') {
+						if (message.middle.size() < 3) {
+							return join(sender_prefix, "461", target, ERR_NEEDMOREPARAMS(message.command));
+						}
+						channel->removeBanMask(message.middle[2]);
+						channel->setMode(channel->getMode() & ~FLAG_CHANNEL_B);
+					}
 					break ;
 				case 'k':
 					if (sign == '+') {
 						// ERR_NEEDMOREPARAMS
-						if (message.middle.size() < 3)
+						if (message.middle.size() < 3) {
 							sender->getServer()->sendMsg(join(sender_prefix, "461", target, ERR_NEEDMOREPARAMS(message.command)), sender);
+						}
 						// ERR_KEYSET
 						else if (channel->getKey().length() > 0) {
 							sender->getServer()->sendMsg(join(sender_prefix, "467", target, ERR_KEYSET(name)), sender);

--- a/src/NumericReplies.cpp
+++ b/src/NumericReplies.cpp
@@ -80,6 +80,16 @@ std::string RPL_ENDOFNAMES(const std::string &channel) {
 	return channel + " :End of /NAMES list";
 }
 
+// 367
+std::string RPL_BANLIST(const std::string &channel, const std::string &banmask) {
+	return channel + " " + banmask;//"<channel> <banid>"
+}
+
+// 368
+std::string RPL_ENDOFBANLIST(const std::string &channel) {
+	return channel + " :End of channel ban list";
+}
+
 // 371
 std::string RPL_INFO(const std::string &string) {
 	return ":" + string;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -43,3 +43,55 @@ std::ostream& operator<<(std::ostream& os, const Message& message) {
 	os << "trailing: " << "|" << message.trailing << "|" << std::endl;
 	return os;
 }
+
+bool isIncluded(std::string ban, std::string user) {
+	size_t u = 0, i = 0;
+
+	while (i < ban.length()) {
+		if (ban[i] == '*') {
+			while (++i < ban.length()) {
+				if (!(ban[i] == '*' || ban[i] == '?')) {
+					break;
+				}
+			}
+			if (i == ban.length()) {
+				return true;
+			}
+			while (ban[i] != user[u]) {
+				if (u == user.length()) {
+					return false;
+				}
+				u++;
+			}
+		} else if (ban[i] == '?') {
+			if (u == user.length()) {
+				return false;
+			}
+			u++;
+		} else {
+			if (u == user.length() || ban[i] != user[u]) {
+				return false;
+			}
+			u++;
+		}
+		i++;
+	}
+	return true;
+}
+
+bool checkMask(std::set<std::string> banlist, std::string prefix) {
+	std::string user = prefix.substr(0, prefix.find("@", 0));
+	std::string nickname = user.substr(0, user.find("!", 0));
+	std::string username = user.substr(user.find("!", 0) + 1);
+	std::string bannick;
+	std::string banuser;
+
+	for (std::set<std::string>::iterator it = banlist.begin();it != banlist.end();it++) {
+		bannick = (*it).substr(0, (*it).find("!", 0));
+		banuser = (*it).substr((*it).find("!", 0) + 1);
+		if (isIncluded(bannick, nickname) && isIncluded(banuser, banuser)) {
+			return true;
+		}
+	}
+	return false;
+}


### PR DESCRIPTION
channel클래스에 _banlist와 getBanList(), setBanMask(), removeBanMask()추가하여
mode 설정에서 ban mask가 추가될 때 setBanMask()를 통해 _banlist에 마스크가 추가되고
mode #foo +b를 요청받으면 _banlist에 저장된 모든 마스크를 출력해준다라고 해석하여 구현하였습니다.

join에서는 _banList의 마스크들을 순회하면서 유저의 prefix가 마스크에 해당하는지 확인 후 채널 가입 여부를 결정하였습니다.

유저와 ban mask 비교는 utils.cpp에서 구현하였습니다.
ban mask 해석 부분에서 서버는 ircserv 하나이기 때문에 @뒤에는 ban mask와 유저의 호스트네임이 동일할 것이라는 가정 하에 구현하여
@의 앞 부분만 고려하였습니다.

@ 앞 부분은 nickname!username의 고정된 형식을 가질 것이라는 가정 하에 
ban mask에 무조건 !가 들어있고 !를 기준으로 ban mask를 분할하고 user또한 nickname과 username을 추출하여 각각에 대하여 비교를 진행하는 로직을 사용하였습니다.

제가 이해한대로 구현 하였는데 맞는지 확인 부탁드립니다!