### PR TITLE
NAMES 응답의 마지막 목록 오류 Fix #50 (+fix segment error #48)

### DIFF
--- a/src/Commands/LIST.cpp
+++ b/src/Commands/LIST.cpp
@@ -19,11 +19,11 @@ std::string LIST(const Message &message, User *sender) {
 	sender->getServer()->sendMsg(join(sender_prefix, "321", target, RPL_LISTSTART()), sender);
 	for (unsigned long i=0; i < channels.size(); i++){
 		channel = sender->getServer()->getChannelByName(channels[i]);
-		visible = toString(channel->getVisibleUsers(sender));
-		topic = channel->getTopic();
 		if (!channel) {
 			continue ;
 		}
+		visible = toString(channel->getVisibleUsers(sender));
+		topic = channel->getTopic();
 
 		// Secret
 		if (channel->getMode() & FLAG_CHANNEL_S) {

--- a/src/Commands/NAMES.cpp
+++ b/src/Commands/NAMES.cpp
@@ -46,7 +46,7 @@ std::string NAMES(const Message &message, User *sender) {
 		if (!user_channels.empty()) {
 			for (chan_it=user_channels.begin(); chan_it!=user_channels.end(); chan_it++) {
 				channel = sender->getServer()->getChannelByName(*chan_it);
-				if (channel->checkVisible(sender)) {
+				if (!channel->checkVisible(sender)) {
 					continue ;
 				}
 				break ;

--- a/src/Commands/NAMES.cpp
+++ b/src/Commands/NAMES.cpp
@@ -39,21 +39,23 @@ std::string NAMES(const Message &message, User *sender) {
 	userlist = std::string();
 	for (std::map<int, User *>::iterator it=server_users.begin(); it!=server_users.end(); it++) {
 		user = (*it).second;
-		if (user->getMode() & FLAG_USER_I || !user_channels.empty()) {
+		user_channels = user->getJoinedChannels();
+		if (user->getMode() & FLAG_USER_I) {
 			continue ;
 		}
-		
-		user_channels = user->getJoinedChannels();
-		for (chan_it=user_channels.begin(); chan_it!=user_channels.end(); chan_it++) {
-			channel = sender->getServer()->getChannelByName(*chan_it);
-			if (channel->checkVisible(sender)) {
-				continue ;
+		if (!user_channels.empty()) {
+			for (chan_it=user_channels.begin(); chan_it!=user_channels.end(); chan_it++) {
+				channel = sender->getServer()->getChannelByName(*chan_it);
+				if (channel->checkVisible(sender)) {
+					continue ;
+				}
+				break ;
 			}
-			break ;
+			if (chan_it != user_channels.end()) {
+				continue;
+			}
 		}
-		if (chan_it == user_channels.end()) {
-			userlist += user->getNickname() + " ";
-		}
+		userlist += user->getNickname() + " ";
 	}
 	// RPL_NAMREPLY
 	sender->getServer()->sendMsg(join(sender_prefix, "353", target, RPL_NAMREPLY("*", userlist)), sender);

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -64,7 +64,10 @@ User *Server::getUserByName(std::string nickname) {
 }
 
 Channel *Server::getChannelByName(std::string channel_name) {
-	return _channels[channel_name];
+	if (_channels.find(channel_name) != _channels.end()) {
+		return _channels[channel_name];
+	}
+	return NULL;
 }
 
 std::vector<std::string> Server::getChannelNames(void) {
@@ -84,7 +87,10 @@ std::string Server::getStartTime(void) {
 }
 
 User	*Server::getUserByFd(int fd) {
-	return _users[fd];
+	if (_users.find(fd) != _users.end()) {
+		return _users[fd];
+	}
+	return NULL;
 }
 
 void Server::run(bool &stop) {


### PR DESCRIPTION
names 요청 시 볼 수 있는 채널의 유저들 목록 전달 후 어떤 채널에도 존재하지 않거나 채널에 속해있지만 그 채널이 요청을 보낸 유저가 볼 수 없는 경우에 대한 유저 목록 전달에 오류가 있어 수정하였습니다.