### PR TITLE
[enhance] textual에 맞도록 응답 메시지 수정 #54

### DIFF
--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -161,6 +161,7 @@ std::string RPL_WHOREPLY(const std::string &channel, const std::string &user, co
 std::string RPL_NAMREPLY(const std::string &channel, const std::string &userlist);
 std::string RPL_LINKS(const std::string &mask, const std::string &server, const std::string &hopcount, const std::string &serverinfo);
 std::string RPL_ENDOFLINKS(const std::string &mask);
+std::string RPL_KILLDONE(const std::string &nickname);
 std::string RPL_ENDOFNAMES(const std::string &channel);
 std::string RPL_BANLIST(const std::string &channel, const std::string &banmask);
 std::string RPL_ENDOFBANLIST(const std::string &channel);

--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -104,6 +104,7 @@ std::string PING(const Message &message, User *sender);
 std::string PONG(const Message &message, User *sender);
 
 // Numeric Replies
+std::string RPL_WELCOME(void);
 std::string RPL_TRACELINK(const std::string &version, const std::string &debuglevel, const std::string &server, const std::string &nextserver, const std::string &info);
 std::string RPL_TRACECONNECTING(const std::string &server);
 std::string RPL_TRACEHANDSHAKE(const std::string &server);

--- a/src/Commands/KILL.cpp
+++ b/src/Commands/KILL.cpp
@@ -10,7 +10,7 @@ std::string KILL(const Message &message, User *sender) {
 	if (message.middle.size() < 2) {
 		return join(sender_prefix, "461", target, ERR_NEEDMOREPARAMS(message.command));
 	}
-	
+
 	// ERR_NOPRIVILEGES
 	if (!(sender->getMode() & FLAG_USER_O)) {
 		return join(sender_prefix, "481", target, ERR_NOPRIVILEGES());
@@ -30,5 +30,9 @@ std::string KILL(const Message &message, User *sender) {
 
 	sender->getServer()->killUser(user);
 
+	sender->getServer()->sendMsg(
+		join(sender_prefix, "361", nickname, RPL_KILLDONE(nickname)),
+		user
+	);
 	return std::string();
 }

--- a/src/Commands/NICK.cpp
+++ b/src/Commands/NICK.cpp
@@ -28,6 +28,9 @@ std::string NICK(const Message &message, User *sender) {
 	sender->reNewNickUpdateTime();
 	sender->addNickHistory(sender->getNickname(), sender->getNickUpdateTime());
 	sender->setNickname(nickname);
+	if (sender->getStatus() == REGISTERED) {
+		return join(sender_prefix, "001", sender->getNickname(), sender->getNickname() + ": Nickname change success!");
+	}
 
 	if (sender->getStatus() == NEED_NICKNAME) {
 		sender->setStatus(NEED_USERREGISTER);

--- a/src/Commands/NOTICE.cpp
+++ b/src/Commands/NOTICE.cpp
@@ -24,12 +24,13 @@ std::string NOTICE(const Message &message, User *sender) {
 						continue;
 					}
 				}
-				std::vector<std::string> user_list = split(channel->getUserList(sender), " ");
-				for (std::vector<std::string>::iterator it2 = user_list.begin();it2 != user_list.end();it2++) {
-					if ((*it2)[0] == '@') {
-						(*it2).erase((*it2).begin());
+				std::set<int> user_fds = channel->getUsers();
+				for (std::set<int>::iterator it2 = user_fds.begin(); it2 != user_fds.end(); ++it2)
+				{
+					User *user = sender->getServer()->getUserByFd(*it2);
+					if (user && user->getNickname() != sender->getNickname()) {
+						sender->getServer()->sendMsg(join(sender_prefix, "NOTICE", *it, ":" + message.trailing), user);
 					}
-					responses.push_back(make_pair("301", *it2));
 				}
 			}
 		} else {//user
@@ -41,7 +42,7 @@ std::string NOTICE(const Message &message, User *sender) {
 
 	for (std::vector<std::pair<std::string, std::string> >::iterator it = responses.begin();it != responses.end();it++) {
 		User *user = sender->getServer()->getUserByName(it->second);
-		sender->getServer()->sendMsg(join(sender_prefix, "301", user->getNickname(), RPL_AWAY(user->getNickname(), message.trailing)), user);
+		sender->getServer()->sendMsg(join(sender_prefix, "NOTICE", user->getNickname(), ":" + message.trailing), user);
 	}
 	return std::string();
 }

--- a/src/Commands/PRIVMSG.cpp
+++ b/src/Commands/PRIVMSG.cpp
@@ -30,12 +30,13 @@ std::string PRIVMSG(const Message &message, User *sender) {
 						continue;
 					}
 				}
-				std::vector<std::string> user_list = split(channel->getUserList(sender), " ");
-				for (std::vector<std::string>::iterator it2 = user_list.begin();it2 != user_list.end();it2++) {
-					if ((*it2)[0] == '@') {
-						(*it2).erase((*it2).begin());
+				std::set<int> user_fds = channel->getUsers();
+				for (std::set<int>::iterator it2 = user_fds.begin(); it2 != user_fds.end(); ++it2)
+				{
+					User *user = sender->getServer()->getUserByFd(*it2);
+					if (user && user->getNickname() != sender->getNickname()) {
+						sender->getServer()->sendMsg(join(sender_prefix, "PRIVMSG", *it, ":" + message.trailing), user);
 					}
-					responses.push_back(make_pair("301", *it2));
 				}
 			}
 		} else {//user
@@ -54,7 +55,7 @@ std::string PRIVMSG(const Message &message, User *sender) {
 			sender->getServer()->sendMsg(join(server_prefix, "404", target, ERR_CANNOTSENDTOCHAN(it->second)), sender);
 		} else {
 			User *user = sender->getServer()->getUserByName(it->second);
-			sender->getServer()->sendMsg(join(sender_prefix, "301", user->getNickname(), RPL_AWAY(user->getNickname(), message.trailing)), user);
+			sender->getServer()->sendMsg(join(sender_prefix, "PRIVMSG", user->getNickname(), ":" + message.trailing), user);
 		}
 	}
 	return std::string();

--- a/src/Commands/TOPIC.cpp
+++ b/src/Commands/TOPIC.cpp
@@ -23,19 +23,27 @@ std::string TOPIC(const Message &message, User *sender) {
 	if (!channel->checkOnChannel(sender)) {
 		return join(sender_prefix, "442", target, ERR_NOTONCHANNEL(channel_name));
 	}
-
 	if (message.trailing.length() > 0) {
 		topic = message.trailing;
 		// ERR_CHANOPRIVSNEEDED
 		if (channel->getMode() & FLAG_CHANNEL_T && !channel->checkPrivilege(sender)) {
 			return join(sender_prefix, "482", target, ERR_CHANOPRIVSNEEDED(channel_name));
 		}
+		if (topic[0] == ':') {
+			topic.erase(0, 1);
+		}
 		channel->setTopic(topic);
+		if (topic.length() > 0) {
+			sender->getServer()->sendMsg(join(sender_prefix, "332", target, RPL_TOPIC(channel_name, topic)), sender);
+		}
+		else {
+			sender->getServer()->sendMsg(join(sender_prefix, "331", target, RPL_NOTOPIC(channel_name)), sender);
+		}
 	}
 	else {
 		topic = channel->getTopic();
 		// RPL_TOPIC
-		if (topic.length()) {
+		if (topic.length() > 0) {
 			sender->getServer()->sendMsg(join(sender_prefix, "332", target, RPL_TOPIC(channel_name, topic)), sender);
 		}
 		else {

--- a/src/Commands/USER.cpp
+++ b/src/Commands/USER.cpp
@@ -18,5 +18,5 @@ std::string USER(const Message &message, User *sender) {
 	if (sender->getStatus() == NEED_USERREGISTER) {
 		sender->setStatus(REGISTERED);
 	}
-	return std::string();
+	return join(sender_prefix, "001", sender->getNickname(), RPL_WELCOME());
 }

--- a/src/NumericReplies.cpp
+++ b/src/NumericReplies.cpp
@@ -128,6 +128,11 @@ std::string RPL_NAMREPLY(const std::string &channel, const std::string &userlist
 	return channel + " :" + userlist;
 }
 
+// 361
+std::string RPL_KILLDONE(const std::string &nickname) {
+	return nickname + " :have been killed!";
+}
+
 // 366
 std::string RPL_ENDOFNAMES(const std::string &channel) {
 	return channel + " :End of /NAMES list";

--- a/src/NumericReplies.cpp
+++ b/src/NumericReplies.cpp
@@ -1,5 +1,10 @@
 #include "../include/Utils.hpp"
 
+// 001
+std::string RPL_WELCOME(void) {
+	return "Welcome to the Introversion-Relay-Chat";
+}
+
 // 221
 std::string RPL_UMODEIS(const std::string &mode) {
 	return mode;


### PR DESCRIPTION
## NICK, USER 수정 사항

### RPL_WELCOME 추가
- USER 명령어로 등록이 완료되면 나오는 welcome 메시지가 나오도록 수정했습니다. (textual에서는 `RPL_WELCOME`까지 응답받아야 등록이 완료된 걸로 인식함)
- NICK으로 닉네임이 변경되었을 때 상단바에서도 닉네임이 변경되도록 하기 위해 `REGISTERED` 상태에서 닉네임 변경시 `RPL_WELCOME`를 응답하도록 수정했습니다.
<img width="243" alt="스크린샷 2022-12-19 오전 1 52 44" src="https://user-images.githubusercontent.com/83565255/208309827-e7e49032-94aa-44b8-9e34-1054eed0540b.png">


## KILL 수정 사항
### RPL_KILL 추가
- KILL로 특정 유저를 차단했을 때 차단당한 유저에게 메시지가 가도록 `RPL_KILL`를 응답합니다.

## PRIVMSG, NOTICE 수정 사항
- 응답에서 `RPL_AWAY` 대신 `PRIVMSG/NOTICE [target] :[message]` 형태로 응답하도록 수정했습니다.
https://ninos.notion.site/IRC-eb6eeaf5b5c24b30b82022aa51a0f483 의 `유저 간 메세지 보내기` 부분 참고


## TOPIC 수정 사항
- 토픽을 변경할 때도 `RPL_TOPIC`, `RPL_NOTOPIC`을 응답하도록 수정했습니다.
- textual에서 `topic #channel :[message]` 형태로 명령어를 입력하면 trailing에 `hello world`가 아닌 `:hello world`가 들어오는 문제가 있어 `:`이 있다면 `:`을 제거하도록 수정했습니다.(textual쪽 문제로 파악됨)

